### PR TITLE
Cleaner steps for register, unregister, getRegistration

### DIFF
--- a/index.html
+++ b/index.html
@@ -643,7 +643,7 @@
             href="#dfn-webapp">webapp</a> to receive <a class="internalDFN"
             href="#dfn-push-message">push messages</a>, unless a prearranged
             trust relationship applies or the user has already granted or
-            denied permission explicitly to this <a class="internalDFN" href=
+            denied permission explicitly for this <a class="internalDFN" href=
             "#dfn-webapp">webapp</a>.
           </li>
           <li>If not granted, reject <var>promise</var> with a <a href=
@@ -666,7 +666,7 @@
               "http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>"
               and terminate these steps.
               </li>
-              <li>When the request has been completed resolve
+              <li>When the request has been completed, resolve
               <var>promise</var> with a <a><code>PushRegistration</code></a>
               providing the details of the retrieved <a class="internalDFN"
               href="#dfn-push-registration">push registration</a>.
@@ -683,12 +683,16 @@
           "http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>"
           and terminate these steps.
           </li>
-          <li>When the request has been completed resolve <var>promise</var>
+          <li>When the request has been completed, resolve <var>promise</var>
           with a <a><code>PushRegistration</code></a> providing the details of
           the new <a class="internalDFN" href="#dfn-push-registration">push
           registration</a>.
           </li>
         </ol>
+        <p class="note">
+          <a href=
+          "https://www.w3.org/Bugs/Public/show_bug.cgi?id=23033"><code>PermissionDeniedError</code></a> has not yet been defined in a specification, this document currently links to the bug for defining it.
+        </p>
         <p>
           The <dfn><code>unregister</code></dfn> method when invoked MUST run
           the following steps:
@@ -717,10 +721,10 @@
           "http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>"
           and terminate these steps.
           </li>
-          <li>When the request has been completed resolve <var>promise</var>
+          <li>When the request has been completed, resolve <var>promise</var>
           with a <a><code>PushRegistration</code></a> providing the details of
-          the unregistered <a class="internalDFN" href=
-          "#dfn-push-registration">push registration</a>.
+          the <a class="internalDFN" href="#dfn-push-registration">push
+          registration</a> which has been unregistered.
           </li>
         </ol>
         <p>
@@ -750,7 +754,7 @@
           "http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>"
           and terminate these steps.
           </li>
-          <li>When the request has been completed resolve <var>promise</var>
+          <li>When the request has been completed, resolve <var>promise</var>
           with a <a><code>PushRegistration</code></a> providing the details of
           the retrieved <a class="internalDFN" href=
           "#dfn-push-registration">push registration</a>.

--- a/index.html
+++ b/index.html
@@ -598,7 +598,7 @@
     notified about the result of the operation. 
     </dd>
 
-    <dt> Promise&lt;DOMString&gt; unregister ()</dt>
+    <dt> Promise&lt;PushRegistration&gt; unregister ()</dt>
     <dd>This method allows a <a class="internalDFN"
     href="#dfn-webapp">webapp</a> to unregister. It
     returns a <a><code>Promise</code></a> that will allow the caller to be 
@@ -618,40 +618,56 @@
   <section>
   <h3>Steps</h3>
   
-	<p class="note">TAG issue: 
-	AbortError is raised when user doesn't grant permissions, not when registration is aborted. 
-	Suggestion: PermissionDeniedError.</p>
-
   <p>The <dfn><code>register</code></dfn> method when invoked MUST run the
     following steps:</p>
   <ol>
     <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.</li>
     <li>Return <var>promise</var> and continue the following steps
     asynchronously.</li>
-    <li>If the scheme of the document url is not <code>https</code> then reject
+    <li>If the scheme of the document url is not <code>https</code>, reject
       <var>promise</var> with a <a href=
       "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
       whose name is "<a href=
       "http://dom.spec.whatwg.org/#securityerror"><code>SecurityError</code></a>"
       and terminate these steps.</li>
-    <li>Ask the user whether they allow the requesting <a class="internalDFN"
+    <li>Ask the user whether they allow the <a class="internalDFN"
       href="#dfn-webapp">webapp</a> to receive <a
       class="internalDFN" href="#dfn-push-message">push messages</a>,
       unless a prearranged trust relationship applies or the user has already
       granted or denied permission explicitly to this <a class="internalDFN"
       href="#dfn-webapp">webapp</a>.</li>
-    <li>If not granted then reject <var>promise</var> with a <a href=
+    <li>If not granted, reject <var>promise</var> with a <a href=
       "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
       whose name is "<a href=
-      "http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>" and
-      terminate these steps.</li>
+      "https://www.w3.org/Bugs/Public/show_bug.cgi?id=23033"><code>PermissionDeniedError</code></a>"
+      and terminate these steps.</li>
+    <li>If the <a class="internalDFN" href="#dfn-webapp">webapp</a> is already
+      registered, run the following substeps:
+      <ol>
+        <li>Retrieve the <a class="internalDFN"
+          href="#dfn-push-registration">push registration</a> associated with the
+          <a class="internalDFN" href="#dfn-webapp">webapp</a>.</li>
+        <li>If there is an error, reject
+          <var>promise</var> with a <a href=
+          "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
+          whose name is "<a href=
+          "http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>"
+          and terminate these steps.</li>
+        <li>When the request has been completed resolve <var>promise</var> with a
+          <a><code>PushRegistration</code></a> providing the details of the
+          retrieved <a class="internalDFN" href="#dfn-push-registration">push
+          registration</a>.</li>
+      </ol>
+    </li>
     <li>Make a request to the system to create a new <a class="internalDFN"
       href="#dfn-push-registration">push registration</a> for the
-      requesting <a class="internalDFN" href="#dfn-webapp">webapp</a>.</li>
-    <li>If there is an error then reject <var>promise</var>
+      <a class="internalDFN" href="#dfn-webapp">webapp</a>.</li>
+    <li>If there is an error, reject <var>promise</var>
       with a <a href=
       "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
-      of the most appropriate type and terminate these steps.</li>
+      whose name is "<a href=
+      "http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>"
+      and terminate these steps.</li>
     <li>When the request has been completed resolve <var>promise</var> with a
       <a><code>PushRegistration</code></a> providing the details of
         the new <a class="internalDFN" href="#dfn-push-registration">push
@@ -664,17 +680,26 @@
     <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.</li>
     <li>Return <var>promise</var> and continue the following steps
       asynchronously.</li>
-    <li>Make a request to the system to deactivate the <a class="internalDFN"
-      href="#dfn-push-registration">push registration</a> of the requesting <a
-      class="internalDFN" href="#dfn-webapp">webapp</a>.</li>
-    <li>If there is an error then reject <var>promise</var> with a <a href=
+    <li>If the <a class="internalDFN" href="#dfn-webapp">webapp</a> is not
+      registered, reject
+      <var>promise</var> with a <a href=
       "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
-      of the most appropriate type and terminate these steps.</li>
+      whose name is "<a href=
+      "http://dom.spec.whatwg.org/#notfounderror"><code>NotFoundError</code></a>"
+      and terminate these steps.</li>
+    <li>Make a request to the system to deactivate the <a class="internalDFN"
+      href="#dfn-push-registration">push registration</a> associated with the <a
+      class="internalDFN" href="#dfn-webapp">webapp</a>.</li>
+    <li>If there is an error, reject <var>promise</var> with a <a href=
+      "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
+      whose name is "<a href=
+      "http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>"
+      and terminate these steps.</li>
     <li>When the request has been completed resolve <var>promise</var> with a
-      <code>DOMString</code> set to the value of the
-      <code>pushRegistrationId</code> attribute of the unregistered <a
-    class="internalDFN" href="#dfn-push-registration">push registration</a>.
-    </li>
+      <a><code>PushRegistration</code></a> providing the details of
+        the unregistered
+        <a class="internalDFN" href="#dfn-push-registration">push
+        registration</a>.</li>
   </ol>
 
   <p>The <dfn><code>getRegistration</code></dfn> method when invoked MUST run
@@ -683,14 +708,21 @@
     <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.</li>
     <li>Return <var>promise</var> and continue the following steps
       asynchronously.</li>
-    <li>Retrieve the <a class="internalDFN"
-      href="#dfn-push-registration">push registration</a> associated with the
-      requesting <a class="internalDFN" href="#dfn-webapp">webapp</a>.</li>
-    <li>If there is an error or the <a class="internalDFN"
-      href="#dfn-webapp">webapp</a> is not registered then reject
+    <li>If the <a class="internalDFN" href="#dfn-webapp">webapp</a> is not
+      registered, reject
       <var>promise</var> with a <a href=
       "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
-      of the most appropriate type and terminate these steps.</li>
+      whose name is "<a href=
+      "http://dom.spec.whatwg.org/#notfounderror"><code>NotFoundError</code></a>"
+      and terminate these steps.</li>
+    <li>Retrieve the <a class="internalDFN"
+      href="#dfn-push-registration">push registration</a> associated with the
+      <a class="internalDFN" href="#dfn-webapp">webapp</a>.</li>
+    <li>If there is an error, reject <var>promise</var> with a <a href=
+      "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
+      whose name is "<a href=
+      "http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>"
+      and terminate these steps.</li>
     <li>When the request has been completed resolve <var>promise</var> with a
       <a><code>PushRegistration</code></a> providing the details of the
       retrieved <a class="internalDFN" href="#dfn-push-registration">push

--- a/index.html
+++ b/index.html
@@ -586,173 +586,116 @@
         "#dfn-push-registration">push registration</a> is allowed per <a class=
         "internalDFN" href="#dfn-webapp">webapp</a>.
       </p>
-      <dl title="interface PushManager" class="idl">
-        <dt>
-          Promise&lt;PushRegistration&gt; register ()
-        </dt>
-        <dd>
-          This method allows a <a class="internalDFN" href=
-          "#dfn-webapp">webapp</a> to create a new <a class="internalDFN" href=
-          "#dfn-push-registration">push registration</a> to receive <a class=
-          "internalDFN" href="#dfn-push-message">push messages</a>. It returns
-          a <a><code>Promise</code></a> that will allow the caller to be
-          notified about the result of the operation.
-        </dd>
-        <dt>
-          Promise&lt;DOMString&gt; unregister ()
-        </dt>
-        <dd>
-          This method allows a <a class="internalDFN" href=
-          "#dfn-webapp">webapp</a> to unregister. It returns a
-          <a><code>Promise</code></a> that will allow the caller to be notified
-          about the result of the operation.
-        </dd>
-        <dt>
-          Promise&lt;PushRegistration&gt; getRegistration ()
-        </dt>
-        <dd>
-          This method allows a <a class="internalDFN" href=
-          "#dfn-webapp">webapp</a> to retrieve the active <a class=
-          "internalDFN" href="#dfn-push-registration">push registration</a>. It
-          returns a <a><code>Promise</code></a> that will allow the caller to
-          be notified about the result of the operation.
-        </dd>
-      </dl>
-      <section>
-        <h3>
-          Steps
-        </h3>
-        <p class="note">
-          TAG issue: AbortError is raised when user doesn't grant permissions,
-          not when registration is aborted. Suggestion: PermissionDeniedError.
-        </p>
-        <p>
-          The <dfn><code>register</code></dfn> method when invoked MUST run the
-          following steps:
-        </p>
-        <ol>
-          <li>Let <var>promise</var> be a new <a><code>Promise</code></a>
-          object and <var>resolver</var> its associated resolver.
-          </li>
-          <li>Return <var>promise</var> and continue the following steps
-          asynchronously.
-          </li>
-          <li>If the scheme of the document url is not <code>https</code>,
-          then:
-            <ol>
-              <li>Let <em>error</em> be a new <a>DOMError</a> object whose name
-              is "<a href=
-              "http://dom.spec.whatwg.org/#securityerror">SecurityError</a>".
-              </li>
-              <li>Invoke <em>resolver</em>'s <a class="internalDFN" href=
-              "#dfn-reject-algorithm">reject algorithm</a> with <em>error</em>
-              as the <code>value</code> argument.
-              </li>
-            </ol>
-          </li>
-          <li>Ask the user whether it allows the requesting <a class=
-          "internalDFN" href="#dfn-webapp">webapp</a> to activate the reception
-          of <a class="internalDFN" href="#dfn-push-message">push messages</a>,
-          unless a prearranged trust relationship applies or the user has
-          already granted or denied permission explicitly to this <a class=
-          "internalDFN" href="#dfn-webapp">webapp</a>.
-          </li>
-          <li>If not granted, run the following sub-steps and terminate these
-          steps:
-            <ol>
-              <li>Let <em>error</em> be a new <a href=
-              "http://dom.spec.whatwg.org/#domerror">DOMError</a> object whose
-              name is "<a href=
-              "http://dom.spec.whatwg.org/#aborterror">AbortError</a>".
-              </li>
-              <li>Invoke <em>resolver</em>'s <a class="internalDFN" href=
-              "#dfn-reject-algorithm">reject algorithm</a> with <em>error</em>
-              as the <code>value</code> argument.
-              </li>
-            </ol>
-          </li>
-          <li>Make a request to the system to create a new <a class=
-          "internalDFN" href="#dfn-push-registration">push registration</a> for
-          the requesting <a class="internalDFN" href="#dfn-webapp">webapp</a>.
-          </li>
-          <li>If there is an error invoke <em>resolver</em>'s <a class=
-          "internalDFN" href="#dfn-reject-algorithm">reject algorithm</a> with
-          no arguments and terminate these steps.
-          </li>
-          <li>When the request has been completed run the following sub-steps:
-            <ol>
-              <li>Let <em>pushRegistration</em> be a new
-              <code>PushRegistration</code> object providing the details of the
-              <a class="internalDFN" href="#dfn-push-registration">push
-              registration</a>.
-              </li>
-              <li>Invoke <em>resolver</em>'s <a class="internalDFN" href=
-              "#dfn-fulfill-algorithm">fulfill algorithm</a> with
-              <em>pushRegistration</em> as the <code>value</code> argument.
-              </li>
-            </ol>
-          </li>
-        </ol>
-        <p>
-          The <dfn><code>unregister</code></dfn> method when invoked MUST run
-          the following steps:
-        </p>
-        <ol>
-          <li>Let <var>promise</var> be a new <a><code>Promise</code></a>
-          object and <var>resolver</var> its associated resolver.
-          </li>
-          <li>Return <var>promise</var> and continue the following steps
-          asynchronously.
-          </li>
-          <li>Make a request to the system to deactivate the <a class=
-          "internalDFN" href="#dfn-push-registration">push registration</a> of
-          the requesting <a class="internalDFN" href="#dfn-webapp">webapp</a>.
-          </li>
-          <li>If there is an error invoke <em>resolver</em>'s <a class=
-          "internalDFN" href="#dfn-reject-algorithm">reject algorithm</a> with
-          no arguments and terminate these steps.
-          </li>
-          <li>When the request has been completed invoke <em>resolver</em>'s
-          <a class="internalDFN" href="#dfn-fulfill-algorithm">fulfill
-          algorithm</a> with a <code>DOMString</code> set to the value of the
-          <code>pushRegistrationId</code> attribute of the unregistered
-          <a class="internalDFN" href="#dfn-push-registration">push
-          registration</a> as the <code>value</code> argument.
-          </li>
-        </ol>
-        <p>
-          The <dfn><code>getRegistration</code></dfn> method when invoked MUST
-          run the following steps:
-        </p>
-        <ol>
-          <li>Let <var>promise</var> be a new <a><code>Promise</code></a>
-          object and <var>resolver</var> its associated resolver.
-          </li>
-          <li>Return <var>promise</var> and continue the following steps
-          asynchronously.
-          </li>
-          <li>Retrieve the <a class="internalDFN" href=
-          "#dfn-push-registration">push registration</a> associated to the
-          requesting <a class="internalDFN" href="#dfn-webapp">webapp</a>
-          </li>
-          <li>If there is an error or the <a class="internalDFN" href=
-          "#dfn-webapp">webapp</a> is not registered invoke <em>resolver</em>'s
-          <a class="internalDFN" href="#dfn-reject-algorithm">reject
-          algorithm</a> algorithm with no arguments and terminate these steps.
-          </li>
-          <li>When the request has been completed run the following sub-steps:
-            <ol>
-              <li>Let <em>pushRegistration</em> be the
-              <code>pushRegistration</code> object associated to the requesting
-              <a class="internalDFN" href="#dfn-webapp">webapp</a>.
-              </li>
-              <li>Invoke <em>resolver</em>'s <a class="internalDFN" href=
-              "#dfn-fulfill-algorithm">fulfill algorithm</a> algorithm with
-              <em>pushRegistration</em> as the <code>value</code> argument.
-              </li>
-            </ol>
-          </li>
-        </ol>
+
+  <dl title="interface PushManager" class="idl">
+
+    <dt> Promise&lt;PushRegistration&gt; register ()</dt>
+    <dd>This method allows a <a class="internalDFN"
+    href="#dfn-webapp">webapp</a> to create a new <a class="internalDFN"
+    href="#dfn-push-registration">push registration</a> to receive <a
+    class="internalDFN" href="#dfn-push-message">push messages</a>. It
+    returns a <a><code>Promise</code></a> that will allow the caller to be 
+    notified about the result of the operation. 
+    </dd>
+
+    <dt> Promise&lt;DOMString&gt; unregister ()</dt>
+    <dd>This method allows a <a class="internalDFN"
+    href="#dfn-webapp">webapp</a> to unregister. It
+    returns a <a><code>Promise</code></a> that will allow the caller to be 
+		notified about the result of the operation.
+    </dd>
+
+    <dt> Promise&lt;PushRegistration&gt; getRegistration ()</dt>
+    <dd>This method allows a <a class="internalDFN"
+    href="#dfn-webapp">webapp</a> to retrieve the active <a
+    class="internalDFN" href="#dfn-push-registration">push registration</a>. It
+    returns a <a><code>Promise</code></a> that will allow the caller to be 
+		notified about the result of the operation. 
+    </dd>
+    
+  </dl>  
+
+  <section>
+  <h3>Steps</h3>
+  
+	<p class="note">TAG issue: 
+	AbortError is raised when user doesn't grant permissions, not when registration is aborted. 
+	Suggestion: PermissionDeniedError.</p>
+
+  <p>The <dfn><code>register</code></dfn> method when invoked MUST run the
+    following steps:</p>
+  <ol>
+    <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.</li>
+    <li>Return <var>promise</var> and continue the following steps
+    asynchronously.</li>
+    <li>If the scheme of the document url is not <code>https</code> then reject
+      <var>promise</var> with a <a href=
+      "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
+      whose name is "<a href=
+      "http://dom.spec.whatwg.org/#securityerror"><code>SecurityError</code></a>"
+      and terminate these steps.</li>
+    <li>Ask the user whether they allow the requesting <a class="internalDFN"
+      href="#dfn-webapp">webapp</a> to receive <a
+      class="internalDFN" href="#dfn-push-message">push messages</a>,
+      unless a prearranged trust relationship applies or the user has already
+      granted or denied permission explicitly to this <a class="internalDFN"
+      href="#dfn-webapp">webapp</a>.</li>
+    <li>If not granted then reject <var>promise</var> with a <a href=
+      "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
+      whose name is "<a href=
+      "http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>" and
+      terminate these steps.</li>
+    <li>Make a request to the system to create a new <a class="internalDFN"
+      href="#dfn-push-registration">push registration</a> for the
+      requesting <a class="internalDFN" href="#dfn-webapp">webapp</a>.</li>
+    <li>If there is an error then reject <var>promise</var>
+      with a <a href=
+      "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
+      of the most appropriate type and terminate these steps.</li>
+    <li>When the request has been completed resolve <var>promise</var> with a
+      <a><code>PushRegistration</code></a> providing the details of
+        the new <a class="internalDFN" href="#dfn-push-registration">push
+        registration</a>.</li>
+  </ol>
+
+  <p>The <dfn><code>unregister</code></dfn> method when invoked MUST run the
+    following steps:</p>
+  <ol>
+    <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.</li>
+    <li>Return <var>promise</var> and continue the following steps
+      asynchronously.</li>
+    <li>Make a request to the system to deactivate the <a class="internalDFN"
+      href="#dfn-push-registration">push registration</a> of the requesting <a
+      class="internalDFN" href="#dfn-webapp">webapp</a>.</li>
+    <li>If there is an error then reject <var>promise</var> with a <a href=
+      "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
+      of the most appropriate type and terminate these steps.</li>
+    <li>When the request has been completed resolve <var>promise</var> with a
+      <code>DOMString</code> set to the value of the
+      <code>pushRegistrationId</code> attribute of the unregistered <a
+    class="internalDFN" href="#dfn-push-registration">push registration</a>.
+    </li>
+  </ol>
+
+  <p>The <dfn><code>getRegistration</code></dfn> method when invoked MUST run
+    the following steps:</p>
+  <ol>
+    <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.</li>
+    <li>Return <var>promise</var> and continue the following steps
+      asynchronously.</li>
+    <li>Retrieve the <a class="internalDFN"
+      href="#dfn-push-registration">push registration</a> associated with the
+      requesting <a class="internalDFN" href="#dfn-webapp">webapp</a>.</li>
+    <li>If there is an error or the <a class="internalDFN"
+      href="#dfn-webapp">webapp</a> is not registered then reject
+      <var>promise</var> with a <a href=
+      "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
+      of the most appropriate type and terminate these steps.</li>
+    <li>When the request has been completed resolve <var>promise</var> with a
+      <a><code>PushRegistration</code></a> providing the details of the
+      retrieved <a class="internalDFN" href="#dfn-push-registration">push
+      registration</a>.</li>
+  </ol>
       </section>
       <section>
         <h3>

--- a/index.html
+++ b/index.html
@@ -691,7 +691,9 @@
         </ol>
         <p class="note">
           <a href=
-          "https://www.w3.org/Bugs/Public/show_bug.cgi?id=23033"><code>PermissionDeniedError</code></a> has not yet been defined in a specification, this document currently links to the bug for defining it.
+          "https://www.w3.org/Bugs/Public/show_bug.cgi?id=23033"><code>PermissionDeniedError</code></a>
+          has not yet been defined in a specification, this document currently
+          links to the bug for defining it.
         </p>
         <p>
           The <dfn><code>unregister</code></dfn> method when invoked MUST run
@@ -973,10 +975,9 @@
         </li>
         <li>Set the <code>data</code> attribute of the
         <a><code>PushMessage</code></a> object to the message data received by
-         the <a class="internalDFN"
-          href="#dfn-user-agent">user agent</a> in the <a class="internalDFN"
-          href="#dfn-push-message">push message</a>, or null if no data was
-          received.
+        the <a class="internalDFN" href="#dfn-user-agent">user agent</a> in the
+        <a class="internalDFN" href="#dfn-push-message">push message</a>, or
+        null if no data was received.
         </li>
         <li>Send an event of type <a><code>push</code></a> including the
         previous <a><code>PushMessage</code></a> object to the <a class=

--- a/index.html
+++ b/index.html
@@ -586,148 +586,176 @@
         "#dfn-push-registration">push registration</a> is allowed per <a class=
         "internalDFN" href="#dfn-webapp">webapp</a>.
       </p>
-
-  <dl title="interface PushManager" class="idl">
-
-    <dt> Promise&lt;PushRegistration&gt; register ()</dt>
-    <dd>This method allows a <a class="internalDFN"
-    href="#dfn-webapp">webapp</a> to create a new <a class="internalDFN"
-    href="#dfn-push-registration">push registration</a> to receive <a
-    class="internalDFN" href="#dfn-push-message">push messages</a>. It
-    returns a <a><code>Promise</code></a> that will allow the caller to be 
-    notified about the result of the operation. 
-    </dd>
-
-    <dt> Promise&lt;PushRegistration&gt; unregister ()</dt>
-    <dd>This method allows a <a class="internalDFN"
-    href="#dfn-webapp">webapp</a> to unregister. It
-    returns a <a><code>Promise</code></a> that will allow the caller to be 
-		notified about the result of the operation.
-    </dd>
-
-    <dt> Promise&lt;PushRegistration&gt; getRegistration ()</dt>
-    <dd>This method allows a <a class="internalDFN"
-    href="#dfn-webapp">webapp</a> to retrieve the active <a
-    class="internalDFN" href="#dfn-push-registration">push registration</a>. It
-    returns a <a><code>Promise</code></a> that will allow the caller to be 
-		notified about the result of the operation. 
-    </dd>
-    
-  </dl>  
-
-  <section>
-  <h3>Steps</h3>
-  
-  <p>The <dfn><code>register</code></dfn> method when invoked MUST run the
-    following steps:</p>
-  <ol>
-    <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.</li>
-    <li>Return <var>promise</var> and continue the following steps
-    asynchronously.</li>
-    <li>If the scheme of the document url is not <code>https</code>, reject
-      <var>promise</var> with a <a href=
-      "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
-      whose name is "<a href=
-      "http://dom.spec.whatwg.org/#securityerror"><code>SecurityError</code></a>"
-      and terminate these steps.</li>
-    <li>Ask the user whether they allow the <a class="internalDFN"
-      href="#dfn-webapp">webapp</a> to receive <a
-      class="internalDFN" href="#dfn-push-message">push messages</a>,
-      unless a prearranged trust relationship applies or the user has already
-      granted or denied permission explicitly to this <a class="internalDFN"
-      href="#dfn-webapp">webapp</a>.</li>
-    <li>If not granted, reject <var>promise</var> with a <a href=
-      "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
-      whose name is "<a href=
-      "https://www.w3.org/Bugs/Public/show_bug.cgi?id=23033"><code>PermissionDeniedError</code></a>"
-      and terminate these steps.</li>
-    <li>If the <a class="internalDFN" href="#dfn-webapp">webapp</a> is already
-      registered, run the following substeps:
-      <ol>
-        <li>Retrieve the <a class="internalDFN"
-          href="#dfn-push-registration">push registration</a> associated with the
-          <a class="internalDFN" href="#dfn-webapp">webapp</a>.</li>
-        <li>If there is an error, reject
-          <var>promise</var> with a <a href=
+      <dl title="interface PushManager" class="idl">
+        <dt>
+          Promise&lt;PushRegistration&gt; register ()
+        </dt>
+        <dd>
+          This method allows a <a class="internalDFN" href=
+          "#dfn-webapp">webapp</a> to create a new <a class="internalDFN" href=
+          "#dfn-push-registration">push registration</a> to receive <a class=
+          "internalDFN" href="#dfn-push-message">push messages</a>. It returns
+          a <a><code>Promise</code></a> that will allow the caller to be
+          notified about the result of the operation.
+        </dd>
+        <dt>
+          Promise&lt;PushRegistration&gt; unregister ()
+        </dt>
+        <dd>
+          This method allows a <a class="internalDFN" href=
+          "#dfn-webapp">webapp</a> to unregister. It returns a
+          <a><code>Promise</code></a> that will allow the caller to be notified
+          about the result of the operation.
+        </dd>
+        <dt>
+          Promise&lt;PushRegistration&gt; getRegistration ()
+        </dt>
+        <dd>
+          This method allows a <a class="internalDFN" href=
+          "#dfn-webapp">webapp</a> to retrieve the active <a class=
+          "internalDFN" href="#dfn-push-registration">push registration</a>. It
+          returns a <a><code>Promise</code></a> that will allow the caller to
+          be notified about the result of the operation.
+        </dd>
+      </dl>
+      <section>
+        <h3>
+          Steps
+        </h3>
+        <p>
+          The <dfn><code>register</code></dfn> method when invoked MUST run the
+          following steps:
+        </p>
+        <ol>
+          <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.
+          </li>
+          <li>Return <var>promise</var> and continue the following steps
+          asynchronously.
+          </li>
+          <li>If the scheme of the document url is not <code>https</code>,
+          reject <var>promise</var> with a <a href=
+          "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
+          whose name is "<a href=
+          "http://dom.spec.whatwg.org/#securityerror"><code>SecurityError</code></a>"
+          and terminate these steps.
+          </li>
+          <li>Ask the user whether they allow the <a class="internalDFN"
+            href="#dfn-webapp">webapp</a> to receive <a class="internalDFN"
+            href="#dfn-push-message">push messages</a>, unless a prearranged
+            trust relationship applies or the user has already granted or
+            denied permission explicitly to this <a class="internalDFN" href=
+            "#dfn-webapp">webapp</a>.
+          </li>
+          <li>If not granted, reject <var>promise</var> with a <a href=
+          "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
+          whose name is "<a href=
+          "https://www.w3.org/Bugs/Public/show_bug.cgi?id=23033"><code>PermissionDeniedError</code></a>"
+          and terminate these steps.
+          </li>
+          <li>If the <a class="internalDFN" href="#dfn-webapp">webapp</a> is
+          already registered, run the following substeps:
+            <ol>
+              <li>Retrieve the <a class="internalDFN" href=
+              "#dfn-push-registration">push registration</a> associated with
+              the <a class="internalDFN" href="#dfn-webapp">webapp</a>.
+              </li>
+              <li>If there is an error, reject <var>promise</var> with a
+              <a href=
+              "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
+              whose name is "<a href=
+              "http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>"
+              and terminate these steps.
+              </li>
+              <li>When the request has been completed resolve
+              <var>promise</var> with a <a><code>PushRegistration</code></a>
+              providing the details of the retrieved <a class="internalDFN"
+              href="#dfn-push-registration">push registration</a>.
+              </li>
+            </ol>
+          </li>
+          <li>Make a request to the system to create a new <a class=
+          "internalDFN" href="#dfn-push-registration">push registration</a> for
+          the <a class="internalDFN" href="#dfn-webapp">webapp</a>.
+          </li>
+          <li>If there is an error, reject <var>promise</var> with a <a href=
           "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
           whose name is "<a href=
           "http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>"
-          and terminate these steps.</li>
-        <li>When the request has been completed resolve <var>promise</var> with a
-          <a><code>PushRegistration</code></a> providing the details of the
-          retrieved <a class="internalDFN" href="#dfn-push-registration">push
-          registration</a>.</li>
-      </ol>
-    </li>
-    <li>Make a request to the system to create a new <a class="internalDFN"
-      href="#dfn-push-registration">push registration</a> for the
-      <a class="internalDFN" href="#dfn-webapp">webapp</a>.</li>
-    <li>If there is an error, reject <var>promise</var>
-      with a <a href=
-      "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
-      whose name is "<a href=
-      "http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>"
-      and terminate these steps.</li>
-    <li>When the request has been completed resolve <var>promise</var> with a
-      <a><code>PushRegistration</code></a> providing the details of
-        the new <a class="internalDFN" href="#dfn-push-registration">push
-        registration</a>.</li>
-  </ol>
-
-  <p>The <dfn><code>unregister</code></dfn> method when invoked MUST run the
-    following steps:</p>
-  <ol>
-    <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.</li>
-    <li>Return <var>promise</var> and continue the following steps
-      asynchronously.</li>
-    <li>If the <a class="internalDFN" href="#dfn-webapp">webapp</a> is not
-      registered, reject
-      <var>promise</var> with a <a href=
-      "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
-      whose name is "<a href=
-      "http://dom.spec.whatwg.org/#notfounderror"><code>NotFoundError</code></a>"
-      and terminate these steps.</li>
-    <li>Make a request to the system to deactivate the <a class="internalDFN"
-      href="#dfn-push-registration">push registration</a> associated with the <a
-      class="internalDFN" href="#dfn-webapp">webapp</a>.</li>
-    <li>If there is an error, reject <var>promise</var> with a <a href=
-      "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
-      whose name is "<a href=
-      "http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>"
-      and terminate these steps.</li>
-    <li>When the request has been completed resolve <var>promise</var> with a
-      <a><code>PushRegistration</code></a> providing the details of
-        the unregistered
-        <a class="internalDFN" href="#dfn-push-registration">push
-        registration</a>.</li>
-  </ol>
-
-  <p>The <dfn><code>getRegistration</code></dfn> method when invoked MUST run
-    the following steps:</p>
-  <ol>
-    <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.</li>
-    <li>Return <var>promise</var> and continue the following steps
-      asynchronously.</li>
-    <li>If the <a class="internalDFN" href="#dfn-webapp">webapp</a> is not
-      registered, reject
-      <var>promise</var> with a <a href=
-      "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
-      whose name is "<a href=
-      "http://dom.spec.whatwg.org/#notfounderror"><code>NotFoundError</code></a>"
-      and terminate these steps.</li>
-    <li>Retrieve the <a class="internalDFN"
-      href="#dfn-push-registration">push registration</a> associated with the
-      <a class="internalDFN" href="#dfn-webapp">webapp</a>.</li>
-    <li>If there is an error, reject <var>promise</var> with a <a href=
-      "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
-      whose name is "<a href=
-      "http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>"
-      and terminate these steps.</li>
-    <li>When the request has been completed resolve <var>promise</var> with a
-      <a><code>PushRegistration</code></a> providing the details of the
-      retrieved <a class="internalDFN" href="#dfn-push-registration">push
-      registration</a>.</li>
-  </ol>
+          and terminate these steps.
+          </li>
+          <li>When the request has been completed resolve <var>promise</var>
+          with a <a><code>PushRegistration</code></a> providing the details of
+          the new <a class="internalDFN" href="#dfn-push-registration">push
+          registration</a>.
+          </li>
+        </ol>
+        <p>
+          The <dfn><code>unregister</code></dfn> method when invoked MUST run
+          the following steps:
+        </p>
+        <ol>
+          <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.
+          </li>
+          <li>Return <var>promise</var> and continue the following steps
+          asynchronously.
+          </li>
+          <li>If the <a class="internalDFN" href="#dfn-webapp">webapp</a> is
+          not registered, reject <var>promise</var> with a <a href=
+          "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
+          whose name is "<a href=
+          "http://dom.spec.whatwg.org/#notfounderror"><code>NotFoundError</code></a>"
+          and terminate these steps.
+          </li>
+          <li>Make a request to the system to deactivate the <a class=
+          "internalDFN" href="#dfn-push-registration">push registration</a>
+          associated with the <a class="internalDFN" href=
+          "#dfn-webapp">webapp</a>.
+          </li>
+          <li>If there is an error, reject <var>promise</var> with a <a href=
+          "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
+          whose name is "<a href=
+          "http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>"
+          and terminate these steps.
+          </li>
+          <li>When the request has been completed resolve <var>promise</var>
+          with a <a><code>PushRegistration</code></a> providing the details of
+          the unregistered <a class="internalDFN" href=
+          "#dfn-push-registration">push registration</a>.
+          </li>
+        </ol>
+        <p>
+          The <dfn><code>getRegistration</code></dfn> method when invoked MUST
+          run the following steps:
+        </p>
+        <ol>
+          <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.
+          </li>
+          <li>Return <var>promise</var> and continue the following steps
+          asynchronously.
+          </li>
+          <li>If the <a class="internalDFN" href="#dfn-webapp">webapp</a> is
+          not registered, reject <var>promise</var> with a <a href=
+          "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
+          whose name is "<a href=
+          "http://dom.spec.whatwg.org/#notfounderror"><code>NotFoundError</code></a>"
+          and terminate these steps.
+          </li>
+          <li>Retrieve the <a class="internalDFN" href=
+          "#dfn-push-registration">push registration</a> associated with the
+          <a class="internalDFN" href="#dfn-webapp">webapp</a>.
+          </li>
+          <li>If there is an error, reject <var>promise</var> with a <a href=
+          "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
+          whose name is "<a href=
+          "http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>"
+          and terminate these steps.
+          </li>
+          <li>When the request has been completed resolve <var>promise</var>
+          with a <a><code>PushRegistration</code></a> providing the details of
+          the retrieved <a class="internalDFN" href=
+          "#dfn-push-registration">push registration</a>.
+          </li>
+        </ol>
       </section>
       <section>
         <h3>


### PR DESCRIPTION
- Less verbose, no need to refer to resolver.
- Use DOMException, not DOMError.
- It's not ok to reject a promise without arguments, always provide a DOMException.
- Resolve unregister promise with PushRegistration.

For more background details see the Promises Guide:
https://github.com/w3ctag/promises-guide

This fixes issue #4.
