### PR TITLE
Set noLegacyStyle: true and adjust structure accordingly

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,9 @@
           // This is important for Rec-track documents, do not copy a patent URI
           // from a random document unless you know what you're doing. If in
           // doubt ask your friendly neighbourhood Team Contact.
-          wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/42538/status"
+          wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/42538/status",
+
+          noLegacyStyle: true
       };
     </script>
   </head>
@@ -368,20 +370,21 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
     </section>
     <section>
       <h2>
-        <a>ServiceWorkerRegistration</a> Interface
+        Extensions to the <a>ServiceWorkerRegistration</a> interface
       </h2>
+      <p>
+        The Service Worker specification defines a <code>ServiceWorkerRegistration</code> interface
+        [[!SERVICE-WORKERS]], which this specification extends.
+      </p>
       <dl title="partial interface ServiceWorkerRegistration" class="idl">
         <dt>
           readonly attribute PushRegistrationManager pushRegistrationManager
         </dt>
-        <dd>
-          The object that exposes the push service management interface.
-        </dd>
       </dl>
     </section>
     <section>
       <h2>
-        <a>PushRegistrationManager</a> Interface
+        <a>PushRegistrationManager</a> interface
       </h2>
       <p>
         The <a>PushRegistrationManager</a> interface defines the operations that enable <a title=
@@ -422,148 +425,142 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
           notified about the result of the operation.
         </dd>
       </dl>
-      <section>
-        <h3>
-          Steps
-        </h3>
-        <p>
-          The <dfn><code>register</code></dfn> method when invoked MUST run the following steps:
-        </p>
-        <ol>
-          <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.
-          </li>
-          <li>Return <var>promise</var> and continue the following steps asynchronously.
-          </li>
-          <li>If the scheme of the document url is not <code>https</code>, reject
-          <var>promise</var> with a <a href=
-          "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a> whose name is
-          "<a href="http://dom.spec.whatwg.org/#securityerror"><code>SecurityError</code></a>" and
-          terminate these steps.
-          </li>
-          <li>Ask the user whether they allow the <a>webapp</a> to receive <a title="push message">
-            push messages</a>, unless a prearranged trust relationship applies or the user has
-            already granted or denied permission explicitly for this <a>webapp</a>.
-          </li>
-          <li>If not granted, reject <var>promise</var> with a <a href=
-          "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a> whose name is
-          "<a href=
-          "https://www.w3.org/Bugs/Public/show_bug.cgi?id=23033"><code>PermissionDeniedError</code></a>"
-          and terminate these steps.
-          </li>
-          <li>If the <a>webapp</a> is already registered, run the following substeps:
-            <ol>
-              <li>Retrieve the <a>push registration</a> associated with the <a>webapp</a>.
-              </li>
-              <li>If there is an error, reject <var>promise</var> with a <a href=
-              "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a> whose name
-              is "<a href="http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>" and
-              terminate these steps.
-              </li>
-              <li>When the request has been completed, resolve <var>promise</var> with a
-              <code>PushRegistration</code> providing the details of the retrieved <a>push
-              registration</a>.
-              </li>
-            </ol>
-          </li>
-          <li>Make a request to the system to create a new <a>push registration</a> for the
-          <a>webapp</a>.
-          </li>
-          <li>If there is an error, reject <var>promise</var> with a <a href=
-          "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a> whose name is
-          "<a href="http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>" and
-          terminate these steps.
-          </li>
-          <li>When the request has been completed, resolve <var>promise</var> with a
-          <a><code>PushRegistration</code></a> providing the details of the new <a>push
-          registration</a>.
-          </li>
-        </ol>
-        <p class="note">
-          <a href=
-          "https://www.w3.org/Bugs/Public/show_bug.cgi?id=23033"><code>PermissionDeniedError</code></a>
-          has not yet been defined in a specification, this document currently links to the bug for
-          defining it.
-        </p>
-        <p>
-          The <dfn><code>unregister</code></dfn> method when invoked MUST run the following steps:
-        </p>
-        <ol>
-          <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.
-          </li>
-          <li>Return <var>promise</var> and continue the following steps asynchronously.
-          </li>
-          <li>If the <a>webapp</a> is not registered, reject <var>promise</var> with a <a href=
-          "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a> whose name is
-          "<a href="http://dom.spec.whatwg.org/#notfounderror"><code>NotFoundError</code></a>" and
-          terminate these steps.
-          </li>
-          <li>Make a request to the system to deactivate the <a>push registration</a> associated
-          with the <a>webapp</a>.
-          </li>
-          <li>If there is an error, reject <var>promise</var> with a <a href=
-          "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a> whose name is
-          "<a href="http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>" and
-          terminate these steps.
-          </li>
-          <li>When the request has been completed, resolve <var>promise</var> with a
-          <a><code>PushRegistration</code></a> providing the details of the <a>push
-          registration</a> which has been unregistered.
-          </li>
-        </ol>
-        <p>
-          The <dfn><code>getRegistration</code></dfn> method when invoked MUST run the following
-          steps:
-        </p>
-        <ol>
-          <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.
-          </li>
-          <li>Return <var>promise</var> and continue the following steps asynchronously.
-          </li>
-          <li>If the <a>webapp</a> is not registered, reject <var>promise</var> with a <a href=
-          "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a> whose name is
-          "<a href="http://dom.spec.whatwg.org/#notfounderror"><code>NotFoundError</code></a>" and
-          terminate these steps.
-          </li>
-          <li>Retrieve the <a>push registration</a> associated with the <a>webapp</a>.
-          </li>
-          <li>If there is an error, reject <var>promise</var> with a <a href=
-          "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a> whose name is
-          "<a href="http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>" and
-          terminate these steps.
-          </li>
-          <li>When the request has been completed, resolve <var>promise</var> with a
-          <a><code>PushRegistration</code></a> providing the details of the retrieved <a>push
-          registration</a>.
-          </li>
-        </ol>
-        <p>
-          The <dfn><code>hasPermission</code></dfn> method when invoked MUST run the following
-          steps:
-        </p>
-        <ol>
-          <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.
-          </li>
-          <li>Return <var>promise</var> and continue the following steps asynchronously.
-          </li>
-          <li>Retrieve the push permission status (<a><code>PushPermissionStatus</code></a>) of the
-          requesting <a>webapp</a>
-          </li>
-          <li>If there is an error, reject <var>promise</var> with no arguments and terminate these
-          steps.
-          </li>
-          <li>When the request has been completed, resolve <var>promise</var> with
-          <a><code>PushPermissionStatus</code></a> providing the push permission status.
-          </li>
-        </ol>
-        <p>
-          Permission to use the push service can be persistent, that is, it does not need to be
-          reconfirmed for subsequent registrations if a valid permission exists.
-        </p>
-        <p>
-          If there is a need to ask for permission, it needs to be done by invoking the
-          <a><code>register</code></a> method.
-        </p>
-      </section>
+      <p>
+        The <dfn><code>register</code></dfn> method when invoked MUST run the following steps:
+      </p>
+      <ol>
+        <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.
+        </li>
+        <li>Return <var>promise</var> and continue the following steps asynchronously.
+        </li>
+        <li>If the scheme of the document url is not <code>https</code>, reject <var>promise</var>
+        with a <a href="http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a>
+        whose name is "<a href=
+        "http://dom.spec.whatwg.org/#securityerror"><code>SecurityError</code></a>" and terminate
+        these steps.
+        </li>
+        <li>Ask the user whether they allow the <a>webapp</a> to receive <a title=
+        "push message">push messages</a>, unless a prearranged trust relationship applies or the
+        user has already granted or denied permission explicitly for this <a>webapp</a>.
+        </li>
+        <li>If not granted, reject <var>promise</var> with a <a href=
+        "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a> whose name is
+        "<a href=
+        "https://www.w3.org/Bugs/Public/show_bug.cgi?id=23033"><code>PermissionDeniedError</code></a>"
+        and terminate these steps.
+        </li>
+        <li>If the <a>webapp</a> is already registered, run the following substeps:
+          <ol>
+            <li>Retrieve the <a>push registration</a> associated with the <a>webapp</a>.
+            </li>
+            <li>If there is an error, reject <var>promise</var> with a <a href=
+            "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a> whose name is
+            "<a href="http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>" and
+            terminate these steps.
+            </li>
+            <li>When the request has been completed, resolve <var>promise</var> with a
+            <a><code>PushRegistration</code></a> providing the details of the retrieved <a>push
+            registration</a>.
+            </li>
+          </ol>
+        </li>
+        <li>Make a request to the system to create a new <a>push registration</a> for the
+        <a>webapp</a>.
+        </li>
+        <li>If there is an error, reject <var>promise</var> with a <a href=
+        "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a> whose name is
+        "<a href="http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>" and
+        terminate these steps.
+        </li>
+        <li>When the request has been completed, resolve <var>promise</var> with a
+        <a><code>PushRegistration</code></a> providing the details of the new <a>push
+        registration</a>.
+        </li>
+      </ol>
+      <p class="note">
+        <a href=
+        "https://www.w3.org/Bugs/Public/show_bug.cgi?id=23033"><code>PermissionDeniedError</code></a>
+        has not yet been defined in a specification, this document currently links to the bug for
+        defining it.
+      </p>
+      <p>
+        The <dfn><code>unregister</code></dfn> method when invoked MUST run the following steps:
+      </p>
+      <ol>
+        <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.
+        </li>
+        <li>Return <var>promise</var> and continue the following steps asynchronously.
+        </li>
+        <li>If the <a>webapp</a> is not registered, reject <var>promise</var> with a <a href=
+        "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a> whose name is
+        "<a href="http://dom.spec.whatwg.org/#notfounderror"><code>NotFoundError</code></a>" and
+        terminate these steps.
+        </li>
+        <li>Make a request to the system to deactivate the <a>push registration</a> associated with
+        the <a>webapp</a>.
+        </li>
+        <li>If there is an error, reject <var>promise</var> with a <a href=
+        "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a> whose name is
+        "<a href="http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>" and
+        terminate these steps.
+        </li>
+        <li>When the request has been completed, resolve <var>promise</var> with a
+        <a><code>PushRegistration</code></a> providing the details of the <a>push registration</a>
+        which has been unregistered.
+        </li>
+      </ol>
+      <p>
+        The <dfn><code>getRegistration</code></dfn> method when invoked MUST run the following
+        steps:
+      </p>
+      <ol>
+        <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.
+        </li>
+        <li>Return <var>promise</var> and continue the following steps asynchronously.
+        </li>
+        <li>If the <a>webapp</a> is not registered, reject <var>promise</var> with a <a href=
+        "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a> whose name is
+        "<a href="http://dom.spec.whatwg.org/#notfounderror"><code>NotFoundError</code></a>" and
+        terminate these steps.
+        </li>
+        <li>Retrieve the <a>push registration</a> associated with the <a>webapp</a>.
+        </li>
+        <li>If there is an error, reject <var>promise</var> with a <a href=
+        "http://dom.spec.whatwg.org/#domexception"><code>DOMException</code></a> whose name is
+        "<a href="http://dom.spec.whatwg.org/#aborterror"><code>AbortError</code></a>" and
+        terminate these steps.
+        </li>
+        <li>When the request has been completed, resolve <var>promise</var> with a
+        <a><code>PushRegistration</code></a> providing the details of the retrieved <a>push
+        registration</a>.
+        </li>
+      </ol>
+      <p>
+        The <dfn><code>hasPermission</code></dfn> method when invoked MUST run the following steps:
+      </p>
+      <ol>
+        <li>Let <var>promise</var> be a new <a><code>Promise</code></a>.
+        </li>
+        <li>Return <var>promise</var> and continue the following steps asynchronously.
+        </li>
+        <li>Retrieve the push permission status (<a><code>PushPermissionStatus</code></a>) of the
+        requesting <a>webapp</a>
+        </li>
+        <li>If there is an error, reject <var>promise</var> with no arguments and terminate these
+        steps.
+        </li>
+        <li>When the request has been completed, resolve <var>promise</var> with
+        <a><code>PushPermissionStatus</code></a> providing the push permission status.
+        </li>
+      </ol>
+      <p>
+        Permission to use the push service can be persistent, that is, it does not need to be
+        reconfirmed for subsequent registrations if a valid permission exists.
+      </p>
+      <p>
+        If there is a need to ask for permission, it needs to be done by invoking the
+        <a><code>register</code></a> method.
+      </p>
       <section>
         <h3>
           Push Registration Persistence
@@ -613,7 +610,7 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
     </section>
     <section>
       <h2>
-        <a>PushRegistration</a> Interface
+        <a>PushRegistration</a> interface
       </h2>
       <p>
         The <a>PushRegistration</a> interface contains information about a specific channel used by
@@ -623,27 +620,30 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
         <dt>
           readonly attribute DOMString endpoint
         </dt>
-        <dd>
-          It MUST return the absolute URL exposed by the <a>push server</a> where the <a>webapp
-          server</a> can send <a title="push message">push messages</a> to this <a>webapp</a>. The
-          value of <code>endpoint</code> may be the same for multiple <a title="webapp">webapps</a>
-          / <a>webapp</a> instances running on multiple devices.
-        </dd>
         <dt>
           readonly attribute DOMString registrationId
         </dt>
-        <dd>
-          It MUST return a univocal identifier of this <a>push registration</a> in the <a>push
-          server</a>. It is used by the <a>webapp server</a> to indicate the target of the
-          <a title="push message">push messages</a> that it submits to the <a>push server</a>. Each
-          pair of <code>registrationId</code> and <code>endpoint</code> is expected to be unique
-          and specific to a particular <a>webapp</a> instance running on a specific device.
-        </dd>
       </dl>
+      <p>
+        When getting the <code id="widl-PushRegistration-endpoint">endpoint</code> attribute, the
+        <a>user agent</a> MUST return the absolute URL exposed by the <a>push server</a> where the
+        <a>webapp server</a> can send <a title="push message">push messages</a> to this
+        <a>webapp</a>. The value of <code>endpoint</code> may be the same for multiple <a title=
+        "webapp">webapps</a> / <a>webapp</a> instances running on multiple devices.
+      </p>
+      <p>
+        When getting the <code id="widl-PushRegistration-registrationId">registrationId</code>
+        attribute the <a>user agent</a> MUST return a univocal identifier of this <a>push
+        registration</a> in the <a>push server</a>. It is used by the <a>webapp server</a> to
+        indicate the target of the <a title="push message">push messages</a> that it submits to the
+        <a>push server</a>. Each pair of <code>registrationId</code> and <code>endpoint</code> is
+        expected to be unique and specific to a particular <a>webapp</a> instance running on a
+        specific device.
+      </p>
     </section>
     <section>
       <h2>
-        <a>PushMessage</a> Interface
+        <a>PushMessage</a> interface
       </h2>
       <p>
         The <a>PushMessage</a> interface represents a received <a>push message</a>.
@@ -652,15 +652,16 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
         <dt>
           readonly attribute DOMString? data
         </dt>
-        <dd>
-          MUST return the message data received by the <a>user agent</a> in the <a>push
-          message</a>, or null if no data was received.
-        </dd>
       </dl>
+      <p>
+        When getting the <code id="widl-PushMessage-data">data</code> attribute the <a>user
+        agent</a> MUST return the message data received by the <a>user agent</a> in the <a>push
+        message</a>, or null if no data was received.
+      </p>
     </section>
     <section>
       <h2>
-        <a>PushRegisterMessage</a> Interface
+        <a>PushRegisterMessage</a> interface
       </h2>
       <p class="note">
         TAG issue: PushRegisterMessage name is confusing as it really occurs when push service
@@ -675,11 +676,12 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
         <dt>
           readonly attribute DOMString registrationId
         </dt>
-        <dd>
-          MUST return the identifier of the <a>push registration</a> to which this event is
-          related.
-        </dd>
       </dl>
+      <p>
+        When getting the <code id="widl-PushRegisterMessage-registrationId">registrationId</code>
+        attribute the <a>user agent</a> MUST return the identifier of the <a>push registration</a>
+        to which this event is related.
+      </p>
     </section>
     <section>
       <h2>
@@ -786,22 +788,44 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
         <dt>
           granted
         </dt>
-        <dd>
-          The <a>webapp</a> has permission to use Push API.
-        </dd>
         <dt>
           denied
         </dt>
-        <dd>
-          The <a>webapp</a> has been denied permission to use Push API.
-        </dd>
         <dt>
           default
         </dt>
-        <dd>
-          The <a>webapp</a> needs to ask for permission in order to use Push API.
-        </dd>
       </dl>
+      <table class="simple">
+        <tr>
+          <th colspan="2">
+            Enumeration description
+          </th>
+        </tr>
+        <tr>
+          <td>
+            <code id="idl-def-PushPermissionStatus.granted">granted</code>
+          </td>
+          <td>
+            The <a>webapp</a> has permission to use Push API.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <code id="idl-def-PushPermissionStatus.denied">denied</code>
+          </td>
+          <td>
+            The <a>webapp</a> has been denied permission to use Push API.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <code id="idl-def-PushPermissionStatus.default">default</code>
+          </td>
+          <td>
+            The <a>webapp</a> needs to ask for permission in order to use Push API.
+          </td>
+        </tr>
+      </table>
     </section>
     <section class="appendix">
       <h2>

--- a/index.html
+++ b/index.html
@@ -633,7 +633,7 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
       </p>
       <p>
         When getting the <code id="widl-PushRegistration-registrationId">registrationId</code>
-        attribute the <a>user agent</a> MUST return a univocal identifier of this <a>push
+        attribute, the <a>user agent</a> MUST return a univocal identifier of this <a>push
         registration</a> in the <a>push server</a>. It is used by the <a>webapp server</a> to
         indicate the target of the <a title="push message">push messages</a> that it submits to the
         <a>push server</a>. Each pair of <code>registrationId</code> and <code>endpoint</code> is
@@ -654,7 +654,7 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
         </dt>
       </dl>
       <p>
-        When getting the <code id="widl-PushMessage-data">data</code> attribute the <a>user
+        When getting the <code id="widl-PushMessage-data">data</code> attribute, the <a>user
         agent</a> MUST return the message data received by the <a>user agent</a> in the <a>push
         message</a>, or null if no data was received.
       </p>
@@ -679,7 +679,7 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
       </dl>
       <p>
         When getting the <code id="widl-PushRegisterMessage-registrationId">registrationId</code>
-        attribute the <a>user agent</a> MUST return the identifier of the <a>push registration</a>
+        attribute, the <a>user agent</a> MUST return the identifier of the <a>push registration</a>
         to which this event is related.
       </p>
     </section>


### PR DESCRIPTION
See http://www.w3.org/respec/ref.html#nolegacystyle for documentation.

Highlights:
- No auto-generated sections for attributes and methods, so less noise in the ToC and further down.
- The generated sections were sorted alphabetically so often differed from the WebIDL ordering, which is confusing. The hand coded markup is not re-ordered.
