### PR TITLE
Nit: Clarify wording of "univocal" identifier

### DIFF
--- a/index.html
+++ b/index.html
@@ -633,7 +633,7 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
       <p>
         When getting the <code><dfn id=
         "widl-PushRegistration-registrationId">registrationId</dfn></code> attribute, the <a>user
-        agent</a> MUST return a univocal identifier of this <a>push registration</a> in the <a>push
+        agent</a> MUST return the canonical identifier of this <a>push registration</a> in the <a>push
         server</a>. It is used by the <a>webapp server</a> to indicate the target of the <a title=
         "push message">push messages</a> that it submits to the <a>push server</a>. Each pair of
         <code>registrationId</code> and <code>endpoint</code> is expected to be unique and specific

--- a/index.html
+++ b/index.html
@@ -633,11 +633,12 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
       <p>
         When getting the <code><dfn id=
         "widl-PushRegistration-registrationId">registrationId</dfn></code> attribute, the <a>user
-        agent</a> MUST return the canonical identifier of this <a>push registration</a> in the <a>push
-        server</a>. It is used by the <a>webapp server</a> to indicate the target of the <a title=
-        "push message">push messages</a> that it submits to the <a>push server</a>. Each pair of
-        <code>registrationId</code> and <code>endpoint</code> is expected to be unique and specific
-        to a particular <a>webapp</a> instance running on a specific device.
+        agent</a> MUST return an identifier that unambiguously identifies this <a>push
+        registration</a> in the <a>push server</a>. It is used by the <a>webapp server</a> to
+        indicate the target of the <a title="push message">push messages</a> that it submits to the
+        <a>push server</a>. Each pair of <code>registrationId</code> and <code>endpoint</code> is
+        expected to be globally unique and specific to a particular <a>webapp</a> instance running
+        on a specific device.
       </p>
     </section>
     <section>


### PR DESCRIPTION
None of the meanings on http://en.wiktionary.org/wiki/univocal made sense in this context; I think the original intention was that these identifiers would be canonical, i.e. you can compare them directly without having to normalize them first.
