### PR TITLE
Make PushEvent's data payload binary instead of just a string

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,19 +159,19 @@
       </p>
       <p>
         <code><a href=
-        'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects'><dfn>Promise</dfn></a></code>
-        is defined in [[!ECMASCRIPT]].
+        'http://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects'><dfn>Promise</dfn></a></code>,
+        and <code><a href=
+        "https://people.mozilla.org/~jorendorff/es6-draft.html#sec-json.parse"><dfn>JSON.parse</dfn></a></code>
+        are defined in [[!ECMASCRIPT]].
       </p>
       <p>
         <code><a href="http://www.w3.org/TR/dom/#eventinit"><dfn>EventInit</dfn></a></code>,
         <code><a href="http://www.w3.org/TR/dom/#domexception"><dfn>DOMException</dfn></a></code>,
         <code><a href="http://www.w3.org/TR/dom/#aborterror"><dfn>AbortError</dfn></a></code>,
         <code><a href=
-        "http://www.w3.org/TR/dom/#notfounderror"><dfn>NotFoundError</dfn></a></code>,
-        <code><a href=
-        "http://www.w3.org/TR/dom/#securityerror"><dfn>SecurityError</dfn></a></code>, and <a href=
-        "http://www.w3.org/TR/dom/#concept-event-constructor"><dfn>steps for constructing
-        events</dfn></a> are defined in [[!DOM]].
+        "http://www.w3.org/TR/dom/#notfounderror"><dfn>NotFoundError</dfn></a></code>, and
+        <code><a href="http://www.w3.org/TR/dom/#securityerror"><dfn>SecurityError</dfn></a></code>
+        are defined in [[!DOM]].
       </p>
       <p>
         <dfn>Service Worker</dfn>, <dfn>ServiceWorkerRegistration</dfn>,
@@ -179,17 +179,17 @@
         [[!SERVICE-WORKERS]].
       </p>
       <p>
-        <code><a href="https://fetch.spec.whatwg.org/#body"><dfn>Body</dfn></a></code>,
-        <code><a href="https://fetch.spec.whatwg.org/#bodyinit"><dfn>BodyInit</dfn></a></code>,
-        <a href="https://fetch.spec.whatwg.org/#concept-bodyinit-extract"><dfn>extracting</dfn></a>
-        a BodyInit, and the Body mixin's <a href=
-        "https://fetch.spec.whatwg.org/#concept-body-body"><dfn>associated body</dfn></a> are
-        defined in [[!FETCH]].
+        The algorithm <a href="http://www.w3.org/TR/encoding/#utf-8-decode"><dfn>utf-8
+        decode</dfn></a> is defined in [[!ENCODING]].
+      </p>
+      <p>
+        <code><a href="http://www.w3.org/TR/FileAPI/#blob"><dfn>Blob</dfn></a></code> is defined in
+        [[!FILEAPI]].
       </p>
       <p>
         <code><a href=
-        "https://heycam.github.io/webidl/#common-BufferSource"><dfn>BufferSource</dfn></a></code>
-        is defined in [[!WEBIDL]].
+        "http://heycam.github.io/webidl/#idl-ArrayBuffer"><dfn>ArrayBuffer</dfn></a></code> is
+        defined in [[!WEBIDL]].
       </p>
       <p>
         The term <dfn>webapp</dfn> refers to a Web application, i.e. an application implemented
@@ -657,6 +657,49 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
     </section>
     <section>
       <h2>
+        <code>PushMessageData</code> interface
+      </h2>
+      <dl title="interface PushMessageData" class="idl">
+        <dt>
+          ArrayBuffer arrayBuffer ()
+        </dt>
+        <dt>
+          Blob blob ()
+        </dt>
+        <dt>
+          JSON json ()
+        </dt>
+        <dt>
+          USVString text ()
+        </dt>
+      </dl>
+      <p>
+        Objects implementing <a><code>PushMessageData</code></a> gain an associated
+        <dfn>bytes</dfn> (a byte sequence, initially empty).
+      </p>
+      <p>
+        The <code><dfn id="widl-PushMessageData-arrayBuffer-ArrayBuffer">arrayBuffer()</dfn></code>
+        method, when invoked, MUST return an <a><code>ArrayBuffer</code></a> whose contents are
+        <var>bytes</var>.
+      </p>
+      <p>
+        The <code><dfn id="widl-PushMessageData-blob-Blob">blob()</dfn></code> method, when
+        invoked, MUST return a <a><code>Blob</code></a> whose contents are <var>bytes</var> and
+        <var>type</var> is not provided.
+      </p>
+      <p>
+        The <code><dfn id="widl-PushMessageData-json-JSON">json()</dfn></code> method, when
+        invoked, MUST return the result of invoking the initial value of
+        <a><code>JSON.parse</code></a> with the result of running <a>utf-8 decode</a> on
+        <var>bytes</var> as argument. This may throw an exception.
+      </p>
+      <p>
+        The <code><dfn id="widl-PushMessageData-text-USVString">text()</dfn></code> method, when
+        invoked, MUST return the result of running <a>utf-8 decode</a> on <var>bytes</var>.
+      </p>
+    </section>
+    <section>
+      <h2>
         Events
       </h2>
       <p>
@@ -693,12 +736,12 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
         "[Constructor(DOMString type, optional PushEventInit eventInitDict), Exposed=ServiceWorker] interface PushEvent : ExtendableEvent"
         class="idl" data-merge="PushEventInit">
           <dt>
-            readonly attribute Body data
+            readonly attribute PushMessageData data
           </dt>
         </dl>
         <dl title="dictionary PushEventInit : EventInit" class="idl">
           <dt>
-            BodyInit data
+            PushMessageData data
           </dt>
         </dl>
         <p>
@@ -712,27 +755,16 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
           <li>Let <var>scope</var> be the <code>ServiceWorkerGlobalScope</code> of the <a>Service
           Worker</a> associated with the <a>webapp</a>.
           </li>
-          <li>Let <var>event</var> be a new <a><code>PushEvent</code></a> whose
-          <a><code>PushEventInit</code></a>'s <code>data</code> member is a <a>BufferSource</a> of
-          the binary message data received by the <a>user agent</a> in the <a>push message</a>
-          (this MUST be empty if no data was received).
+          <li>Let <var>event</var> be a new <a><code>PushEvent</code></a>, whose <code>data</code>
+          attribute is a new <a><code>PushMessageData</code></a>, whose <a>bytes</a> is the binary
+          message data received by the <a>user agent</a> in the <a>push message</a>, or an empty
+          byte sequence if no data was received.
           </li>
           <li>
             <a>Queue a task</a> to <a title="fire a simple event">fire <var>event</var> as a simple
             event</a> named <code>push</code> at <var>scope</var>.
           </li>
         </ol>
-        <p>
-          When a constructor of the <a><code>PushEvent</code></a> interface, or of an interface
-          that inherits from the <a><code>PushEvent</code></a> interface, is invoked, the usual
-          <a>steps for constructing events</a> MUST be modified as follows: if the
-          <var>eventInitDict</var> contains a dictionary member with key "<code id=
-          "widl-PushEventInit-data">data</code>" and value of type <a><code>BodyInit</code></a>,
-          then instead of setting the <code>data</code> attribute of the event to the value of that
-          dictionary member, set the <code id="widl-PushEvent-data">data</code> attribute's
-          <a>associated body</a> to the byte stream that is the result of <a>extracting</a> that
-          dictionary member.
-        </p>
       </section>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -179,17 +179,24 @@
         [[!SERVICE-WORKERS]].
       </p>
       <p>
-        The algorithm <a href="http://www.w3.org/TR/encoding/#utf-8-decode"><dfn>utf-8
-        decode</dfn></a> is defined in [[!ENCODING]].
+        The algorithms <a href="http://www.w3.org/TR/encoding/#utf-8-encode"><dfn>utf-8
+        encode</dfn></a>, and <a href="http://www.w3.org/TR/encoding/#utf-8-decode"><dfn>utf-8
+        decode</dfn></a> are defined in [[!ENCODING]].
       </p>
       <p>
         <code><a href="http://www.w3.org/TR/FileAPI/#blob"><dfn>Blob</dfn></a></code> is defined in
         [[!FILEAPI]].
       </p>
       <p>
+        <code><a href="https://heycam.github.io/webidl/#idl-any"><dfn>Any</dfn></a></code>,
         <code><a href=
-        "http://heycam.github.io/webidl/#idl-ArrayBuffer"><dfn>ArrayBuffer</dfn></a></code> is
-        defined in [[!WEBIDL]].
+        "http://heycam.github.io/webidl/#idl-ArrayBuffer"><dfn>ArrayBuffer</dfn></a></code>,
+        <code><a href=
+        "http://heycam.github.io/webidl/#common-BufferSource"><dfn>BufferSource</dfn></a></code>,
+        <a href="http://heycam.github.io/webidl/#dfn-get-buffer-source-copy"><dfn>get a copy of the
+        bytes held by the buffer source</dfn></a>, and <code><a href=
+        "http://heycam.github.io/webidl/#idl-USVString"><dfn>USVString</dfn></a></code> are defined
+        in [[!WEBIDL]].
       </p>
       <p>
         The term <dfn>webapp</dfn> refers to a Web application, i.e. an application implemented
@@ -659,7 +666,11 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
       <h2>
         <code>PushMessageData</code> interface
       </h2>
-      <dl title="interface PushMessageData" class="idl">
+      <div class="idl" title="typedef (Blob or BufferSource or USVString) PushMessageDataInit">
+      </div>
+      <dl title=
+      "[Constructor(PushMessageDataInit init), Exposed=ServiceWorker] interface PushMessageData"
+      class="idl" data-merge="PushMessageDataInit">
         <dt>
           ArrayBuffer arrayBuffer ()
         </dt>
@@ -667,7 +678,7 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
           Blob blob ()
         </dt>
         <dt>
-          JSON json ()
+          Any json ()
         </dt>
         <dt>
           USVString text ()
@@ -675,7 +686,7 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
       </dl>
       <p>
         <a><code>PushMessageData</code></a> objects have an associated <dfn>bytes</dfn> (a byte
-        sequence, initially empty).
+        sequence) set on creation.
       </p>
       <p>
         The <code><dfn id="widl-PushMessageData-arrayBuffer-ArrayBuffer">arrayBuffer()</dfn></code>
@@ -688,7 +699,7 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
         <var>type</var> is not provided.
       </p>
       <p>
-        The <code><dfn id="widl-PushMessageData-json-JSON">json()</dfn></code> method, when
+        The <code><dfn id="widl-PushMessageData-json-Any">json()</dfn></code> method, when
         invoked, MUST return the result of invoking the initial value of
         <a><code>JSON.parse</code></a> with the result of running <a>utf-8 decode</a> on
         <var>bytes</var> as argument. This may throw an exception.
@@ -697,6 +708,53 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
         The <code><dfn id="widl-PushMessageData-text-USVString">text()</dfn></code> method, when
         invoked, MUST return the result of running <a>utf-8 decode</a> on <var>bytes</var>.
       </p>
+      <p>
+        The <code><dfn>PushMessageData(<var>init</var>)</dfn></code> constructor must return a new
+        <a><code>PushMessageData</code></a> object with <a>bytes</a> set to the result of <a title=
+        "extract a byte sequence">extracting a byte sequence</a> from <var>init</var>.
+      </p>
+      <p>
+        To <dfn>extract a byte sequence</dfn> from <var>object</var>, run these steps:
+      </p>
+      <ol>
+        <li>
+          <p>
+            Let <var>bytes</var> be an empty byte sequence.
+          </p>
+        </li>
+        <li>
+          <p>
+            Switch on <var>object</var>'s type:
+          </p>
+          <dl>
+            <dt>
+              <a><code>Blob</code></a>
+            </dt>
+            <dd>
+              Set <var>bytes</var> to a copy of <var>object</var>'s contents.
+            </dd>
+            <dt>
+              <a><code>BufferSource</code></a>
+            </dt>
+            <dd>
+              Set <var>bytes</var> to a <a title=
+              "get a copy of the bytes held by the buffer source">copy of</a> <var>object</var>.
+            </dd>
+            <dt>
+              <a><code>USVString</code></a>
+            </dt>
+            <dd>
+              Set <var>bytes</var> to the result of running <a>utf-8 encode</a> on
+              <var>object</var>.
+            </dd>
+          </dl>
+        </li>
+        <li>
+          <p>
+            Return <var>bytes</var>.
+          </p>
+        </li>
+      </ol>
     </section>
     <section>
       <h2>

--- a/index.html
+++ b/index.html
@@ -706,8 +706,14 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
         The <code><dfn id="widl-PushMessageData-text-USVString">text()</dfn></code> method, when
         invoked, MUST return the result of running <a>utf-8 decode</a> on <var>bytes</var>.
       </p>
-      <div class="idl" title="typedef (Blob or BufferSource or USVString) PushMessageDataInit">
-      </div>
+      <div class="idl" title="typedef USVString PushMessageDataInit"></div>
+      <p class="note">
+        In future, <a><code>PushMessageDataInit</code></a> is likely to be a union type that
+        includes types such as <a><code>Blob</code></a> and <a><code>BufferSource</code></a>. The
+        <a title="extract a byte sequence">algorithm</a> below would be extended, rather like the
+        Fetch standard's <a href="https://fetch.spec.whatwg.org/#concept-bodyinit-extract">extract
+        a byte stream</a> algorithm.
+      </p>
       <p>
         To <dfn>extract a byte sequence</dfn> from <var>object</var>, run these steps:
       </p>
@@ -722,19 +728,6 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
             Switch on <var>object</var>'s type:
           </p>
           <dl>
-            <dt>
-              <a><code>Blob</code></a>
-            </dt>
-            <dd>
-              Set <var>bytes</var> to a copy of <var>object</var>'s contents.
-            </dd>
-            <dt>
-              <a><code>BufferSource</code></a>
-            </dt>
-            <dd>
-              Set <var>bytes</var> to a <a title=
-              "get a copy of the bytes held by the buffer source">copy of</a> <var>object</var>.
-            </dd>
             <dt>
               <a><code>USVString</code></a>
             </dt>
@@ -808,11 +801,10 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
           <li>Let <var>scope</var> be the <code>ServiceWorkerGlobalScope</code> of the <a>Service
           Worker</a> associated with the <a>webapp</a>.
           </li>
-          <li>Let <var>event</var> be a new <a><code>PushEvent</code></a>, initialized with a
-          <a><code>PushEventInit</code></a> whose <code>data</code> member is an
-          <a><code>ArrayBuffer</code></a> containing the binary message data received by the
-          <a>user agent</a> in the <a>push message</a>, or an empty <a><code>ArrayBuffer</code></a>
-          if no data was received.
+          <li>Let <var>event</var> be a new <a><code>PushEvent</code></a>, whose <code id=
+          "widl-PushEvent-data">data</code> attribute is a new <a><code>PushMessageData</code></a>
+          with <a>bytes</a> set to the binary message data received by the <a>user agent</a> in the
+          <a>push message</a>, or an empty byte sequence if no data was received.
           </li>
           <li>
             <a>Queue a task</a> to <a title="fire a simple event">fire <var>event</var> as a simple
@@ -826,10 +818,10 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
           <var>eventInitDict</var> contains a dictionary member with key "<code id=
           "widl-PushEventInit-data">data</code>" and value of type
           <a><code>PushMessageDataInit</code></a>, then instead of setting the <code>data</code>
-          attribute of the event to the value of that dictionary member, set the <code id=
-          "widl-PushEvent-data">data</code> attribute to a new <a><code>PushMessageData</code></a>
-          with <a>bytes</a> set to the result of <a title="extract a byte sequence">extracting a
-          byte sequence</a> from that dictionary member.
+          attribute of the event to the value of that dictionary member, set the <code>data</code>
+          attribute to a new <a><code>PushMessageData</code></a> with <a>bytes</a> set to the
+          result of <a title="extract a byte sequence">extracting a byte sequence</a> from that
+          dictionary member.
         </p>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -190,13 +190,12 @@
         [[!FILEAPI]].
       </p>
       <p>
-        <code><a href="https://heycam.github.io/webidl/#idl-any"><dfn>Any</dfn></a></code>,
+        <code><a href="http://www.w3.org/TR/WebIDL/#idl-any"><dfn>Any</dfn></a></code>,
         <code><a href=
         "http://heycam.github.io/webidl/#idl-ArrayBuffer"><dfn>ArrayBuffer</dfn></a></code>,
         <code><a href=
         "http://heycam.github.io/webidl/#common-BufferSource"><dfn>BufferSource</dfn></a></code>,
-        <a href="http://heycam.github.io/webidl/#dfn-get-buffer-source-copy"><dfn>get a copy of the
-        bytes held by the buffer source</dfn></a>, and <code><a href=
+        and <code><a href=
         "http://heycam.github.io/webidl/#idl-USVString"><dfn>USVString</dfn></a></code> are defined
         in [[!WEBIDL]].
       </p>
@@ -666,7 +665,7 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
     </section>
     <section>
       <h2>
-        <code>PushMessageData</code> interface
+        <a>PushMessageData</a> interface
       </h2>
       <dl title="[NoInterfaceObject] interface PushMessageData" class="idl">
         <dt>
@@ -683,8 +682,8 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
         </dt>
       </dl>
       <p>
-        <a><code>PushMessageData</code></a> objects have an associated <dfn>bytes</dfn> (a byte
-        sequence) set on creation.
+        <a>PushMessageData</a> objects have an associated <dfn>bytes</dfn> (a byte sequence) set on
+        creation.
       </p>
       <p>
         The <code><dfn id="widl-PushMessageData-arrayBuffer-ArrayBuffer">arrayBuffer()</dfn></code>
@@ -699,8 +698,8 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
       <p>
         The <code><dfn id="widl-PushMessageData-json-Any">json()</dfn></code> method, when invoked,
         MUST return the result of invoking the initial value of <a><code>JSON.parse</code></a> with
-        the result of running <a>utf-8 decode</a> on <var>bytes</var> as argument. This may throw
-        an exception.
+        the result of running <a>utf-8 decode</a> on <var>bytes</var> as argument. Re-throw any
+        exceptions thrown by <a><code>JSON.parse</code></a>.
       </p>
       <p>
         The <code><dfn id="widl-PushMessageData-text-USVString">text()</dfn></code> method, when
@@ -708,25 +707,19 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
       </p>
       <div class="idl" title="typedef USVString PushMessageDataInit"></div>
       <p class="note">
-        In future, <a><code>PushMessageDataInit</code></a> is likely to be a union type that
-        includes types such as <a><code>Blob</code></a> and <a><code>BufferSource</code></a>. The
-        <a title="extract a byte sequence">algorithm</a> below would be extended, rather like the
-        Fetch standard's <a href="https://fetch.spec.whatwg.org/#concept-bodyinit-extract">extract
-        a byte stream</a> algorithm.
+        In future, <a>PushMessageDataInit</a> is likely to be a union type that includes types such
+        as <a><code>Blob</code></a> and <a><code>BufferSource</code></a>. The <a title=
+        "extract a byte sequence">algorithm</a> below would be extended, rather like the Fetch
+        standard's <a href="https://fetch.spec.whatwg.org/#concept-bodyinit-extract">extract a byte
+        stream</a> algorithm.
       </p>
       <p>
         To <dfn>extract a byte sequence</dfn> from <var>object</var>, run these steps:
       </p>
       <ol>
-        <li>
-          <p>
-            Let <var>bytes</var> be an empty byte sequence.
-          </p>
+        <li>Let <var>bytes</var> be an empty byte sequence.
         </li>
-        <li>
-          <p>
-            Switch on <var>object</var>'s type:
-          </p>
+        <li>Switch on <var>object</var>'s type:
           <dl>
             <dt>
               <a><code>USVString</code></a>
@@ -737,10 +730,7 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
             </dd>
           </dl>
         </li>
-        <li>
-          <p>
-            Return <var>bytes</var>.
-          </p>
+        <li>Return <var>bytes</var>.
         </li>
       </ol>
     </section>
@@ -779,7 +769,7 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
           The <a>PushEvent</a> interface represents a received <a>push message</a>.
         </p>
         <dl title=
-        "[Constructor(DOMString type, PushEventInit eventInitDict), Exposed=ServiceWorker] interface PushEvent : ExtendableEvent"
+        "[Constructor(DOMString type, optional PushEventInit eventInitDict), Exposed=ServiceWorker] interface PushEvent : ExtendableEvent"
         class="idl" data-merge="PushEventInit">
           <dt>
             readonly attribute PushMessageData data
@@ -787,7 +777,7 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
         </dl>
         <dl title="dictionary PushEventInit : EventInit" class="idl">
           <dt>
-            required PushMessageDataInit data
+            PushMessageDataInit data
           </dt>
         </dl>
         <p>
@@ -801,10 +791,10 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
           <li>Let <var>scope</var> be the <code>ServiceWorkerGlobalScope</code> of the <a>Service
           Worker</a> associated with the <a>webapp</a>.
           </li>
-          <li>Let <var>event</var> be a new <a><code>PushEvent</code></a>, whose <code id=
-          "widl-PushEvent-data">data</code> attribute is a new <a><code>PushMessageData</code></a>
-          with <a>bytes</a> set to the binary message data received by the <a>user agent</a> in the
-          <a>push message</a>, or an empty byte sequence if no data was received.
+          <li>Let <var>event</var> be a new <a>PushEvent</a>, whose <code id="widl-PushEvent-data">
+            data</code> attribute is a new <a>PushMessageData</a> with <a>bytes</a> set to the
+            binary message data received by the <a>user agent</a> in the <a>push message</a>, or an
+            empty byte sequence if no data was received.
           </li>
           <li>
             <a>Queue a task</a> to <a title="fire a simple event">fire <var>event</var> as a simple
@@ -812,16 +802,15 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
           </li>
         </ol>
         <p>
-          When a constructor of the <a><code>PushEvent</code></a> interface, or of an interface
-          that inherits from the <a><code>PushEvent</code></a> interface, is invoked, the usual
-          <a>steps for constructing events</a> MUST be modified as follows: if the
-          <var>eventInitDict</var> contains a dictionary member with key "<code id=
-          "widl-PushEventInit-data">data</code>" and value of type
-          <a><code>PushMessageDataInit</code></a>, then instead of setting the <code>data</code>
-          attribute of the event to the value of that dictionary member, set the <code>data</code>
-          attribute to a new <a><code>PushMessageData</code></a> with <a>bytes</a> set to the
-          result of <a title="extract a byte sequence">extracting a byte sequence</a> from that
-          dictionary member.
+          When a constructor of the <a>PushEvent</a> interface, or of an interface that inherits
+          from the <a>PushEvent</a> interface, is invoked, the usual <a>steps for constructing
+          events</a> MUST be modified as follows: instead of setting the <code>data</code>
+          attribute of the event to the value of the <var>eventInitDict</var>'s "<code id=
+          "widl-PushEventInit-data">data</code>" member, set the <code>data</code> attribute to a
+          new <a>PushMessageData</a> with <a>bytes</a> set to the result of <a title=
+          "extract a byte sequence">extracting a byte sequence</a> from that dictionary member, or
+          an empty byte sequence if <var>eventInitDict</var> is not provided or has no
+          "<code>data</code>" member.
         </p>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -674,8 +674,8 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
         </dt>
       </dl>
       <p>
-        Objects implementing <a><code>PushMessageData</code></a> gain an associated
-        <dfn>bytes</dfn> (a byte sequence, initially empty).
+        <a><code>PushMessageData</code></a> objects have an associated <dfn>bytes</dfn> (a byte
+        sequence, initially empty).
       </p>
       <p>
         The <code><dfn id="widl-PushMessageData-arrayBuffer-ArrayBuffer">arrayBuffer()</dfn></code>
@@ -733,7 +733,7 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
           The <a>PushEvent</a> interface represents a received <a>push message</a>.
         </p>
         <dl title=
-        "[Constructor(DOMString type, optional PushEventInit eventInitDict), Exposed=ServiceWorker] interface PushEvent : ExtendableEvent"
+        "[Constructor(DOMString type, PushEventInit eventInitDict), Exposed=ServiceWorker] interface PushEvent : ExtendableEvent"
         class="idl" data-merge="PushEventInit">
           <dt>
             readonly attribute PushMessageData data
@@ -741,7 +741,7 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
         </dl>
         <dl title="dictionary PushEventInit : EventInit" class="idl">
           <dt>
-            PushMessageData data
+            required PushMessageData data
           </dt>
         </dl>
         <p>
@@ -755,10 +755,11 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
           <li>Let <var>scope</var> be the <code>ServiceWorkerGlobalScope</code> of the <a>Service
           Worker</a> associated with the <a>webapp</a>.
           </li>
-          <li>Let <var>event</var> be a new <a><code>PushEvent</code></a>, whose <code>data</code>
-          attribute is a new <a><code>PushMessageData</code></a>, whose <a>bytes</a> is the binary
-          message data received by the <a>user agent</a> in the <a>push message</a>, or an empty
-          byte sequence if no data was received.
+          <li>Let <var>event</var> be a new <a><code>PushEvent</code></a>, whose <code><dfn id=
+          "widl-PushEvent-data">data</dfn></code> attribute is a new
+          <a><code>PushMessageData</code></a>, whose <a>bytes</a> is the binary message data
+          received by the <a>user agent</a> in the <a>push message</a>, or an empty byte sequence
+          if no data was received.
           </li>
           <li>
             <a>Queue a task</a> to <a title="fire a simple event">fire <var>event</var> as a simple

--- a/index.html
+++ b/index.html
@@ -169,9 +169,11 @@
         <code><a href="http://www.w3.org/TR/dom/#domexception"><dfn>DOMException</dfn></a></code>,
         <code><a href="http://www.w3.org/TR/dom/#aborterror"><dfn>AbortError</dfn></a></code>,
         <code><a href=
-        "http://www.w3.org/TR/dom/#notfounderror"><dfn>NotFoundError</dfn></a></code>, and
-        <code><a href="http://www.w3.org/TR/dom/#securityerror"><dfn>SecurityError</dfn></a></code>
-        are defined in [[!DOM]].
+        "http://www.w3.org/TR/dom/#notfounderror"><dfn>NotFoundError</dfn></a></code>,
+        <code><a href=
+        "http://www.w3.org/TR/dom/#securityerror"><dfn>SecurityError</dfn></a></code>, and <a href=
+        "http://www.w3.org/TR/dom/#concept-event-constructor"><dfn>steps for constructing
+        events</dfn></a> are defined in [[!DOM]].
       </p>
       <p>
         <dfn>Service Worker</dfn>, <dfn>ServiceWorkerRegistration</dfn>,
@@ -666,11 +668,7 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
       <h2>
         <code>PushMessageData</code> interface
       </h2>
-      <div class="idl" title="typedef (Blob or BufferSource or USVString) PushMessageDataInit">
-      </div>
-      <dl title=
-      "[Constructor(PushMessageDataInit init), Exposed=ServiceWorker] interface PushMessageData"
-      class="idl" data-merge="PushMessageDataInit">
+      <dl title="[NoInterfaceObject] interface PushMessageData" class="idl">
         <dt>
           ArrayBuffer arrayBuffer ()
         </dt>
@@ -699,20 +697,17 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
         <var>type</var> is not provided.
       </p>
       <p>
-        The <code><dfn id="widl-PushMessageData-json-Any">json()</dfn></code> method, when
-        invoked, MUST return the result of invoking the initial value of
-        <a><code>JSON.parse</code></a> with the result of running <a>utf-8 decode</a> on
-        <var>bytes</var> as argument. This may throw an exception.
+        The <code><dfn id="widl-PushMessageData-json-Any">json()</dfn></code> method, when invoked,
+        MUST return the result of invoking the initial value of <a><code>JSON.parse</code></a> with
+        the result of running <a>utf-8 decode</a> on <var>bytes</var> as argument. This may throw
+        an exception.
       </p>
       <p>
         The <code><dfn id="widl-PushMessageData-text-USVString">text()</dfn></code> method, when
         invoked, MUST return the result of running <a>utf-8 decode</a> on <var>bytes</var>.
       </p>
-      <p>
-        The <code><dfn>PushMessageData(<var>init</var>)</dfn></code> constructor must return a new
-        <a><code>PushMessageData</code></a> object with <a>bytes</a> set to the result of <a title=
-        "extract a byte sequence">extracting a byte sequence</a> from <var>init</var>.
-      </p>
+      <div class="idl" title="typedef (Blob or BufferSource or USVString) PushMessageDataInit">
+      </div>
       <p>
         To <dfn>extract a byte sequence</dfn> from <var>object</var>, run these steps:
       </p>
@@ -799,7 +794,7 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
         </dl>
         <dl title="dictionary PushEventInit : EventInit" class="idl">
           <dt>
-            required PushMessageData data
+            required PushMessageDataInit data
           </dt>
         </dl>
         <p>
@@ -813,10 +808,10 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
           <li>Let <var>scope</var> be the <code>ServiceWorkerGlobalScope</code> of the <a>Service
           Worker</a> associated with the <a>webapp</a>.
           </li>
-          <li>Let <var>event</var> be a new <a><code>PushEvent</code></a>, whose <code><dfn id=
-          "widl-PushEvent-data">data</dfn></code> attribute is a new
-          <a><code>PushMessageData</code></a>, whose <a>bytes</a> is the binary message data
-          received by the <a>user agent</a> in the <a>push message</a>, or an empty byte sequence
+          <li>Let <var>event</var> be a new <a><code>PushEvent</code></a>, initialized with a
+          <a><code>PushEventInit</code></a> whose <code>data</code> member is an
+          <a><code>ArrayBuffer</code></a> containing the binary message data received by the
+          <a>user agent</a> in the <a>push message</a>, or an empty <a><code>ArrayBuffer</code></a>
           if no data was received.
           </li>
           <li>
@@ -824,6 +819,18 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
             event</a> named <code>push</code> at <var>scope</var>.
           </li>
         </ol>
+        <p>
+          When a constructor of the <a><code>PushEvent</code></a> interface, or of an interface
+          that inherits from the <a><code>PushEvent</code></a> interface, is invoked, the usual
+          <a>steps for constructing events</a> MUST be modified as follows: if the
+          <var>eventInitDict</var> contains a dictionary member with key "<code id=
+          "widl-PushEventInit-data">data</code>" and value of type
+          <a><code>PushMessageDataInit</code></a>, then instead of setting the <code>data</code>
+          attribute of the event to the value of that dictionary member, set the <code id=
+          "widl-PushEvent-data">data</code> attribute to a new <a><code>PushMessageData</code></a>
+          with <a>bytes</a> set to the result of <a title="extract a byte sequence">extracting a
+          byte sequence</a> from that dictionary member.
+        </p>
       </section>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -167,14 +167,29 @@
         <code><a href="http://www.w3.org/TR/dom/#domexception"><dfn>DOMException</dfn></a></code>,
         <code><a href="http://www.w3.org/TR/dom/#aborterror"><dfn>AbortError</dfn></a></code>,
         <code><a href=
-        "http://www.w3.org/TR/dom/#notfounderror"><dfn>NotFoundError</dfn></a></code>, and
-        <code><a href="http://www.w3.org/TR/dom/#securityerror"><dfn>SecurityError</dfn></a></code>
-        are defined in [[!DOM]].
+        "http://www.w3.org/TR/dom/#notfounderror"><dfn>NotFoundError</dfn></a></code>,
+        <code><a href=
+        "http://www.w3.org/TR/dom/#securityerror"><dfn>SecurityError</dfn></a></code>, and <a href=
+        "http://www.w3.org/TR/dom/#concept-event-constructor"><dfn>steps for constructing
+        events</dfn></a> are defined in [[!DOM]].
       </p>
       <p>
         <dfn>Service Worker</dfn>, <dfn>ServiceWorkerRegistration</dfn>,
         <dfn>ServiceWorkerGlobalScope</dfn>, and <dfn>ExtendableEvent</dfn> are defined in
         [[!SERVICE-WORKERS]].
+      </p>
+      <p>
+        <code><a href="https://fetch.spec.whatwg.org/#body"><dfn>Body</dfn></a></code>,
+        <code><a href="https://fetch.spec.whatwg.org/#bodyinit"><dfn>BodyInit</dfn></a></code>,
+        <a href="https://fetch.spec.whatwg.org/#concept-bodyinit-extract"><dfn>extracting</dfn></a>
+        a BodyInit, and the Body mixin's <a href=
+        "https://fetch.spec.whatwg.org/#concept-body-body"><dfn>associated body</dfn></a> are
+        defined in [[!FETCH]].
+      </p>
+      <p>
+        <code><a href=
+        "https://heycam.github.io/webidl/#common-BufferSource"><dfn>BufferSource</dfn></a></code>
+        is defined in [[!WEBIDL]].
       </p>
       <p>
         The term <dfn>webapp</dfn> refers to a Web application, i.e. an application implemented
@@ -678,23 +693,12 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
         "[Constructor(DOMString type, optional PushEventInit eventInitDict), Exposed=ServiceWorker] interface PushEvent : ExtendableEvent"
         class="idl" data-merge="PushEventInit">
           <dt>
-            readonly attribute DOMString? data
+            readonly attribute Body data
           </dt>
         </dl>
-        <p>
-          When getting the <code id="widl-PushEventInit-data">data</code> attribute of a
-          <code>PushEventInit</code> object, the <a>user agent</a> MUST return the message data
-          received by the <a>user agent</a> in the <a>push message</a>, or null if no data was
-          received.
-        </p>
-        <p>
-          When getting the <code id="widl-PushEvent-data">data</code> attribute of a
-          <code>PushEvent</code>, the <a>user agent</a> MUST return the message data received by
-          the <a>user agent</a> in the <a>push message</a>, or null if no data was received.
-        </p>
         <dl title="dictionary PushEventInit : EventInit" class="idl">
           <dt>
-            DOMString? data
+            BodyInit data
           </dt>
         </dl>
         <p>
@@ -708,15 +712,27 @@ navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
           <li>Let <var>scope</var> be the <code>ServiceWorkerGlobalScope</code> of the <a>Service
           Worker</a> associated with the <a>webapp</a>.
           </li>
-          <li>Let <var>event</var> be a new <a><code>PushEvent</code></a> whose <code>data</code>
-          attribute is the message data received by the <a>user agent</a> in the <a>push
-          message</a>, or null if no data was received.
+          <li>Let <var>event</var> be a new <a><code>PushEvent</code></a> whose
+          <a><code>PushEventInit</code></a>'s <code>data</code> member is a <a>BufferSource</a> of
+          the binary message data received by the <a>user agent</a> in the <a>push message</a>
+          (this MUST be empty if no data was received).
           </li>
           <li>
             <a>Queue a task</a> to <a title="fire a simple event">fire <var>event</var> as a simple
             event</a> named <code>push</code> at <var>scope</var>.
           </li>
         </ol>
+        <p>
+          When a constructor of the <a><code>PushEvent</code></a> interface, or of an interface
+          that inherits from the <a><code>PushEvent</code></a> interface, is invoked, the usual
+          <a>steps for constructing events</a> MUST be modified as follows: if the
+          <var>eventInitDict</var> contains a dictionary member with key "<code id=
+          "widl-PushEventInit-data">data</code>" and value of type <a><code>BodyInit</code></a>,
+          then instead of setting the <code>data</code> attribute of the event to the value of that
+          dictionary member, set the <code id="widl-PushEvent-data">data</code> attribute's
+          <a>associated body</a> to the byte stream that is the result of <a>extracting</a> that
+          dictionary member.
+        </p>
       </section>
       <section>
         <h2>


### PR DESCRIPTION
This exposes binary data as a Body mixin from the Fetch spec,
as discussed on https://github.com/w3c/push-api/issues/83
