### PR TITLE
Fixing definition of push message

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,14 +238,14 @@
           Push message
         </h2>
         <p>
-          A <dfn>push message</dfn> is an indication to a <a>webapp</a> that there is new
-          information for it from the <a>application server</a>. All or part of this information
-          MAY be contained in the <a>push message</a> itself.
+          A <dfn>push message</dfn> is data sent to a <a>webapp</a> from an <a>application
+          server</a>.
         </p>
         <p>
-          A <a>push message</a> MUST be delivered to the <a>active worker</a> associated with the
+          A <a>push message</a> is delivered to the <a>active worker</a> associated with the
           <a>push subscription</a> to which the message was submitted. If the worker or its
-          <a>webapp</a> is not currently running, the worker must be started to enable delivery.
+          <a>webapp</a> is not currently running, the worker is started to
+          enable delivery.
         </p>
       </section>
       <section>


### PR DESCRIPTION
The definition here was a little strange, probably as a legacy of the original "no data" API.

It also contained unnecessary normative language.
