### PR TITLE
Removing tidy warnings with haxx

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,9 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'>
-</script>
+    </script>
     <script class="remove">
-// (this is to make tidy happy)
+    // (this is to make tidy happy)
       // See http://www.w3.org/respec/ for ReSpec documentation.
       var respecConfig = {
           specStatus: "ED",
@@ -36,14 +36,14 @@
               name: "Bryan Sullivan",
               company: "AT&T",
               companyURL: "http://www.att.com/",
-              note: "until <time>2015-05-01</time>",
+              note: "until <time>2015-05-01<\u002ftime>",
               w3cid: "41539"
             },
             {
               name: "Eduardo Fullea",
               company: "Telefonica",
               companyURL: "http://www.telefonica.com/",
-              note: "until <time>2015-05-01</time>",
+              note: "until <time>2015-05-01<\u002ftime>",
               w3cid: "53513"
             }
           ],


### PR DESCRIPTION
Tidy warns about "</".  It doesn't warn about "<\u002f".
