### PR TITLE
Adding make check and circle CI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*~
+*.swp
+.support
+tidy-html5

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+support_dir ?= $(CURDIR)/.support
+tidy ?= $(shell which tidy 2>/dev/null)
+ifeq (,$(tidy))
+tidy := $(support_dir)/bin/tidy
+endif
+cmake ?= cmake
+
+.PHONY: install_tidy
+install_tidy: $(tidy)
+$(tidy):
+	if [ ! -d tidy-html5 ]; then \
+	  mkdir -p tidy-html5; \
+	  git clone -q --depth 10 https://github.com/htacg/tidy-html5.git tidy-html5; \
+	fi
+	cd tidy-html5/build/cmake && \
+	  $(cmake) ../.. -DCMAKE_INSTALL_PREFIX=$(support_dir) -DCMAKE_BUILD_TYPE=Release && \
+	  make && make install
+
+.PHONY: check
+check: install_tidy
+	$(tidy) -quiet -config tidyconf.txt -errors index.html
+
+.PHONY: tidy
+tidy: install_tidy
+	-$(tidy) -quiet -config tidyconf.txt -modify index.html

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,10 @@
+dependencies:
+  cache_directories:
+    - cmake-3.3.1-Linux-x86_64
+    - .support
+  pre:
+    - if [[ ! -d cmake-3.3.1-Linux-x86_64 ]]; then wget http://www.cmake.org/files/v3.3/cmake-3.3.1-Linux-x86_64.tar.gz && tar xzf cmake-3.3.1-Linux-x86_64.tar.gz && rm -f cmake-3.3.1-Linux-x86_64.tar.gz; fi
+    - if [[ ! -d .support ]]; then make cmake="$PWD/cmake-3.3.1-Linux-x86_64/bin/cmake" install_tidy; fi
+test:
+  override:
+    - make check

--- a/index.html
+++ b/index.html
@@ -407,8 +407,7 @@
         <h2>
           Example
         </h2>
-        <pre class="example highlight">
-// https://example.com/serviceworker.js
+        <pre class="example highlight">// https://example.com/serviceworker.js
 this.onpush = function(event) {
   console.log(event.data);
   // From here we can write the data to IndexedDB, send it to any open


### PR DESCRIPTION
This just ensures that commits and pull requests always have tidy run on them.  That way we can avoid the manual checks we've been doing.

I used Circle CI because it has a nicer interface than Travis.  Neither were able to install or run tidy without a fair bit of extra mucking around because they run the ancient Ubuntu 12.04.

@mvano PTAL
