### PR TITLE
PushMessageData.arrayBuffer() re-throws exceptions from ArrayBuffer creation

### DIFF
--- a/index.html
+++ b/index.html
@@ -723,7 +723,8 @@ navigator.serviceWorker.register('serviceworker.js').then(
       <p>
         The <code><dfn id="widl-PushMessageData-arrayBuffer-ArrayBuffer">arrayBuffer()</dfn></code>
         method, when invoked, MUST return an <a><code>ArrayBuffer</code></a> whose contents are
-        <var>bytes</var>.
+        <var>bytes</var>. Exceptions thrown during the creation of the <a><code>ArrayBuffer</code></a>
+        object are re-thrown.
       </p>
       <p>
         The <code><dfn id="widl-PushMessageData-blob-Blob">blob()</dfn></code> method, when


### PR DESCRIPTION
The specific consequence of this change is that RangeError exceptions are expected to be thrown when there is a memory allocation failure while attempting to create the ArrayBuffer.  I am following Anne van Kesteren's suggestion that this be worded as a "re-throw". The specific exceptions to be thrown are governed by the ECMAScript specification

Thread: https://groups.google.com/a/chromium.org/forum/m/#!topic/blink-dev/pZ9kld0LehA
