### PR TITLE
Add note about single push service per user agent.

### DIFF
--- a/index.html
+++ b/index.html
@@ -444,6 +444,13 @@
           push service serves the <a>push endpoint</a> or <a data-lt="push endpoints">endpoints</a>
           for the <a>push subscriptions</a> it serves.
         </p>
+        <p>
+          There is only one <a>push service</a> per <a>user agent</a> and it cannot be changed
+          from the default value. This limitation is due to a variety of performance-related
+          concerns, including the complexity of running reliable <a>push services</a> and the
+          impact on battery lifetime if there were an unbounded set of <a>push services</a> to
+          which a device could connect.
+        </p>
       </section>
       <section>
         <h2>


### PR DESCRIPTION
This is a follow up to https://github.com/w3c/push-api/issues/243. The PR adds a note explaining that there is only one push service per user agent and provides some reasoning for the design decision. Our engineers spent a fair bit of time trying to understand if there was a way to change the push service and this text would have saved them some time.