### PR TITLE
Define exposure of the Push API interfaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -672,6 +672,7 @@ navigator.serviceWorker.register('serviceworker.js').then(
         The <a>PushManager</a> interface defines the operations to access <a>push services</a>.
       </p>
       <pre class="idl">
+        [Exposed=(Window,Worker)]
         interface PushManager {
           [SameObject] static readonly attribute FrozenArray&lt;DOMString&gt; supportedContentEncodings;
 
@@ -845,6 +846,7 @@ navigator.serviceWorker.register('serviceworker.js').then(
             (BufferSource or DOMString)? applicationServerKey = null;
           };
 
+          [Exposed=(Window,Worker)]
           interface PushSubscriptionOptions {
             readonly attribute boolean userVisibleOnly;
             [SameObject] readonly attribute ArrayBuffer? applicationServerKey;
@@ -883,6 +885,7 @@ navigator.serviceWorker.register('serviceworker.js').then(
         A <a>PushSubscription</a> object represents a <a>push subscription</a>.
       </p>
       <pre class="idl">
+        [Exposed=(Window,Worker)]
         interface PushSubscription {
           readonly attribute USVString endpoint;
           readonly attribute DOMTimeStamp? expirationTime;
@@ -1117,6 +1120,7 @@ navigator.serviceWorker.register('serviceworker.js').then(
           interface [[!SERVICE-WORKERS]], which this specification extends.
         </p>
         <pre class="idl">
+          [Exposed=(Window,Worker)]
           partial interface ServiceWorkerGlobalScope {
             attribute EventHandler onpush;
             attribute EventHandler onpushsubscriptionchange;


### PR DESCRIPTION
https://w3c.github.io/ServiceWorker/v1/#serviceworkerregistration-interface defines this for `ServiceWorkerRegistration`, this is what UAs implement, so we should make sure our interfaces match.