### PR TITLE
Add [SecureContext] annotations to our interfaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -665,6 +665,7 @@ navigator.serviceWorker.register('serviceworker.js').then(
         [[!SERVICE-WORKERS]], which this specification extends.
       </p>
       <pre class="idl">
+        [SecureContext]
         partial interface ServiceWorkerRegistration {
           readonly attribute PushManager pushManager;
         };
@@ -683,7 +684,7 @@ navigator.serviceWorker.register('serviceworker.js').then(
         The <a>PushManager</a> interface defines the operations to access <a>push services</a>.
       </p>
       <pre class="idl">
-        [Exposed=(Window,Worker)]
+        [Exposed=(Window,Worker), SecureContext]
         interface PushManager {
           [SameObject] static readonly attribute FrozenArray&lt;DOMString&gt; supportedContentEncodings;
 
@@ -856,7 +857,7 @@ navigator.serviceWorker.register('serviceworker.js').then(
             (BufferSource or DOMString)? applicationServerKey = null;
           };
 
-          [Exposed=(Window,Worker)]
+          [Exposed=(Window,Worker), SecureContext]
           interface PushSubscriptionOptions {
             readonly attribute boolean userVisibleOnly;
             [SameObject] readonly attribute ArrayBuffer? applicationServerKey;
@@ -899,7 +900,7 @@ navigator.serviceWorker.register('serviceworker.js').then(
         A <a>PushSubscription</a> object represents a <a>push subscription</a>.
       </p>
       <pre class="idl">
-        [Exposed=(Window,Worker)]
+        [Exposed=(Window,Worker), SecureContext]
         interface PushSubscription {
           readonly attribute USVString endpoint;
           readonly attribute DOMTimeStamp? expirationTime;
@@ -1091,7 +1092,7 @@ navigator.serviceWorker.register('serviceworker.js').then(
         <dfn>PushMessageData</dfn> interface
       </h2>
       <pre class="idl">
-        [Exposed=ServiceWorker]
+        [Exposed=ServiceWorker, SecureContext]
         interface PushMessageData {
           ArrayBuffer arrayBuffer();
           Blob blob();
@@ -1161,7 +1162,7 @@ navigator.serviceWorker.register('serviceworker.js').then(
           interface [[!SERVICE-WORKERS]], which this specification extends.
         </p>
         <pre class="idl">
-          [Exposed=(Window,Worker)]
+          [Exposed=ServiceWorker, SecureContext]
           partial interface ServiceWorkerGlobalScope {
             attribute EventHandler onpush;
             attribute EventHandler onpushsubscriptionchange;
@@ -1220,7 +1221,7 @@ navigator.serviceWorker.register('serviceworker.js').then(
               PushMessageDataInit data;
             };
 
-            [Constructor(DOMString type, optional PushEventInit eventInitDict), Exposed=ServiceWorker]
+            [Constructor(DOMString type, optional PushEventInit eventInitDict), Exposed=ServiceWorker, SecureContext]
             interface PushEvent : ExtendableEvent {
               readonly attribute PushMessageData? data;
             };
@@ -1383,7 +1384,7 @@ navigator.serviceWorker.register('serviceworker.js').then(
               PushSubscription oldSubscription = null;
             };
 
-            [Constructor(DOMString type, optional PushSubscriptionChangeInit eventInitDict), Exposed=ServiceWorker]
+            [Constructor(DOMString type, optional PushSubscriptionChangeInit eventInitDict), Exposed=ServiceWorker, SecureContext]
             interface PushSubscriptionChangeEvent : ExtendableEvent {
               readonly attribute PushSubscription? newSubscription;
               readonly attribute PushSubscription? oldSubscription;


### PR DESCRIPTION
Fixes #282


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/beverloo/push-api/secure-context.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/push-api/7bc329f...beverloo:16dca29.html)