### PR TITLE
Some Push Services require use of webpush-vapid

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,6 +306,8 @@
         type</dfn></a></code>, <code><a href=
         "https://heycam.github.io/webidl/#notallowederror"><dfn>NotAllowedError</dfn></a></code>,
         <code><a href=
+        "https://heycam.github.io/webidl/#notsupportederror"><dfn>NotSupportedError</dfn></a></code>,
+        <code><a href=
         "https://heycam.github.io/webidl/#idl-USVString"><dfn>USVString</dfn></a></code> and
         <code><a href="https://heycam.github.io/webidl/#get-the-underlying-value"><dfn>get the
         underlying value</dfn></a></code> are defined in [[!WEBIDL]].
@@ -736,6 +738,12 @@ navigator.serviceWorker.register('serviceworker.js').then(
             </li>
           </ol>
         </li>
+        <li>If the <var>options</var> argument does not include a non-null value for the
+        <code><a data-link-for="PushSubscriptionOptions">applicationServerKey</a></code> attribute,
+        and the <a>push service</a> requires one to be given, reject <var>promise</var> with a
+        <a>DOMException</a> whose name is "<code><a>NotSupportedError</a></code>" and terminate
+        these steps.
+        </li>
         <li>Let <var>registration</var> be the <a>PushManager</a>'s associated <a>service worker
         registration</a>.
         </li>
@@ -884,6 +892,11 @@ navigator.serviceWorker.register('serviceworker.js').then(
           (that is, 65 octets, starting with an 0x04 octet). When provided as a
           <code><a>DOMString</a></code>, the value MUST be encoded using the base64url encoding
           [[!RFC7515]].
+        </p>
+        <p>
+          User agents MAY reject a subscription attempt when <a data-link-for=
+          "PushSubscriptionOptions">applicationServerKey</a> is not present and the <a>push
+          service</a> requires one for operational reasons.
         </p>
         <p>
           The <code><a data-link-for="PushSubscriptionOptions">applicationServerKey</a></code> MUST


### PR DESCRIPTION
While not the original intention, some push services require use of
VAPID for operational reasons. This should be reflected in the spec.

Fixes #279


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/beverloo/push-api/vapid-requirement.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/push-api/7bc329f...beverloo:8c09661.html)