### PR TITLE
Update privacy and server choice...

### DIFF
--- a/index.html
+++ b/index.html
@@ -480,15 +480,9 @@
         <p>
           The <a>user agent</a> connects to the <a>push service</a> used to create <a>push subscriptions</a>.
           <a>User agents</a> MAY limit the choice of <a>push services</a> available. Reasons for doing so
-          Include performance-related concerns such as service availability (including whether services are
+          include performance-related concerns such as service availability (including whether services are
           blocked by firewalls in specific countries, or networks at workplaces and the like), reliability,
-          the ability to control impact on battery lifetime, and agreements to steer metadata to, or away from,
-          specific <a>push services</a>.
-        </p>
-        <p class="note">
-          The contents of a <a>push message</a> are encrypted [[!WEBPUSH-ENCRYPTION]], but message metadata,
-          including the sender and receiver, the timing and frequency, and the size of messages, are all
-          exposed to the <a>push service</a>.
+          impact on battery lifetime, and agreements to steer metadata to, or away from, specific <a>push services</a>.
         </p>
       </section>
       <section>
@@ -506,7 +500,6 @@
       <h2>
         Security and privacy considerations
       </h2>
-      <div class="note">
         <p>
           The contents of a <a>push message</a> are encrypted [[!WEBPUSH-ENCRYPTION]]. However,
           the <a>push service</a> is still exposed to the metadata of messages sent by an

--- a/index.html
+++ b/index.html
@@ -478,19 +478,17 @@
           the <a>push subscriptions</a> it serves.
         </p>
         <p>
-          The <a>user agent</a> is responsible for choosing the <a>push service</a> used for
-          creating <a>push subscriptions</a>. There usually is a pre-existing relationship between
-          the <a>user agent</a> and the <a>push service</a> due to a variety of performance-related
-          concerns, including the complexity of running reliable <a>push services</a> and the impact
-          on battery lifetime if there were an unbounded set of <a>push services</a> to which a
-          device could connect.
+          The <a>user agent</a> connects to the <a>push service</a> used to create <a>push subscriptions</a>.
+          <a>User agents</a> MAY limit the choice of <a>push services</a> available. Reasons for doing so
+          Include performance-related concerns such as service availability (including whether services are
+          blocked by firewalls in specific countries, or networks at workplaces and the like), reliability,
+          the ability to control impact on battery lifetime, and agreements to steer metadata to, or away from,
+          specific <a>push services</a>.
         </p>
         <p class="note">
-          Even though the contents of a <a>push message</a> are encrypted [[!WEBPUSH-ENCRYPTION]],
-          the <a>push service</a> is still exposed to the metadata of messages sent by an
-          <a>application server</a> to a <a>user agent</a> over a <a>push subscription</a>. This
-          includes the timing, frequency and size of messages. Only size can be mitigated by the
-          addition of padding.
+          The contents of a <a>push message</a> are encrypted [[!WEBPUSH-ENCRYPTION]], but message metadata,
+          including the sender and receiver, the timing and frequency, and the size of messages, are all
+          exposed to the <a>push service</a>.
         </p>
       </section>
       <section>
@@ -508,6 +506,27 @@
       <h2>
         Security and privacy considerations
       </h2>
+      <div class="note">
+        <p>
+          The contents of a <a>push message</a> are encrypted [[!WEBPUSH-ENCRYPTION]]. However,
+          the <a>push service</a> is still exposed to the metadata of messages sent by an
+          <a>application server</a> to a <a>user agent</a> over a <a>push subscription</a>. This
+          includes the timing, frequency and size of messages. Other than changing <a>push services</a>,
+          which user agents may disallow, the only known mitigation is to increase the apparent message
+          size by padding.
+        </p>
+        <p>
+          There is no guarantee that a <a>push message</a> was sent by an <a>application server</a>
+          having the same origin as the <a>webapp</a>. The <a>application server</a> is able to share
+          the details necessary to use a <a>push subscription</a> with a third party at its own
+          discretion.
+        </p>
+      </div>
+      <p>
+        The following requirements are intended to protect the privacy and security of the user as far
+        as possible, and subject to meeting that goal, to protect the integrity of the
+        <a>application server</a>'s communication with the user.
+      </p>
       <p>
         <a>User agents</a> MUST NOT provide Push API access to <a>webapps</a> without the
         <a>express permission</a> of the user. <a>User agents</a> MUST acquire consent for
@@ -554,12 +573,6 @@
         "secure context">secure contexts</a>. This provides better protection for the user against
         man-in-the-middle attacks intended to obtain push subscription data. Browsers may ignore
         this rule for development purposes only.
-      </p>
-      <p>
-        There is no guarantee that a <a>push message</a> was sent by an <a>application server</a>
-        having the same origin as the <a>webapp</a>. The <a>application server</a> is able to share
-        the details necessary to use a <a>push subscription</a> with a third party at its own
-        discretion.
       </p>
     </section>
     <section class="informative" id="pushframework">


### PR DESCRIPTION
Fix #293
See also comments on #287
Editorial.

Clarifies that user agents MAY limit the choice of push server, and why they might do so.
Reframes the Privacy Section slightly to identify the concerns that the implementation requirements address.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/pull/294.html" title="Last updated on Apr 13, 2018, 11:48 AM GMT (a684749)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/294/3a6b97e...a684749.html" title="Last updated on Apr 13, 2018, 11:48 AM GMT (a684749)">Diff</a>