### PR TITLE
chore:add PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+Closes #???
+
+The following tasks have been completed:
+
+ * [ ] Confirmed there are no ReSpec/BikeShed errors or warnings.
+ * [ ] Modified Web platform tests (link to pull request)
+
+Implementation commitment:
+
+ * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
+ * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
+ * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


### PR DESCRIPTION
(👋 I'm an Outreachy intern at Mozilla and assisting @marcoscaceres  with specifications)

During TPAC [it was proposed](https://www.w3.org/2018/10/26-WebPlat-minutes.html#item03) to adopt something closer to the [WHATWG Working Mode](https://whatwg.org/working-mode). That is, before merging a pull request, the following things should be in place:

* [Web Platform tests](https://github.com/web-platform-tests/wpt) for the feature/fix being proposed.
* Explicit implementer commitment to add/fix whatever is being proposed.

This template provides some simple checkboxes to make sure the above conditions are met. We strongly encourage using this template, since it helps implementers find tests and sends a strong signal about implementation commitment. You are free to modify it to better suit your needs (see an [example of a modified template](https://github.com/w3c/manifest/blob/gh-pages/PULL_REQUEST_TEMPLATE.md)). 

If you are unsure how to create Web Platform Tests, there are some great [docs available](https://web-platform-tests.org/). We are also here to help you get started if you need guidance. 