### PR TITLE
chore(w3c.json): switch to WebAppsWG

### DIFF
--- a/w3c.json
+++ b/w3c.json
@@ -1,6 +1,6 @@
 {
   "group": [
-    "83482"
+    "114929"
   ],
   "contacts": [
     "siusin"


### PR DESCRIPTION
Just a heads up that this repo is now moving to the new WebAppsWG. While this is happening over next few days, and folks are joining the new working group, any IPR bot might get upset if you try to merge any pull requests.
