### PR TITLE
Update to Web IDL changes to optional dictionary defaulting

### DIFF
--- a/index.html
+++ b/index.html
@@ -534,9 +534,9 @@
         interface PushManager {
           [SameObject] static readonly attribute FrozenArray&lt;DOMString&gt; supportedContentEncodings;
 
-          Promise&lt;PushSubscription&gt; subscribe(optional PushSubscriptionOptionsInit options);
+          Promise&lt;PushSubscription&gt; subscribe(optional PushSubscriptionOptionsInit options = {});
           Promise&lt;PushSubscription?&gt; getSubscription();
-          Promise&lt;PushPermissionState&gt; permissionState(optional PushSubscriptionOptionsInit options);
+          Promise&lt;PushPermissionState&gt; permissionState(optional PushSubscriptionOptionsInit options = {});
         };
       </pre>
       <p>
@@ -1046,7 +1046,7 @@
           <dfn>PushEvent</dfn> Interface
         </h2>
         <pre class="idl" data-cite="service-workers">
-            [Constructor(DOMString type, optional PushEventInit eventInitDict), Exposed=ServiceWorker, SecureContext]
+            [Constructor(DOMString type, optional PushEventInit eventInitDict = {}), Exposed=ServiceWorker, SecureContext]
             interface PushEvent : ExtendableEvent {
               readonly attribute PushMessageData? data;
             };
@@ -1221,7 +1221,7 @@
             <dfn>PushSubscriptionChangeEvent</dfn> Interface
           </h2>
           <pre class="idl" data-cite="service-workers">
-            [Constructor(DOMString type, optional PushSubscriptionChangeInit eventInitDict), Exposed=ServiceWorker, SecureContext]
+            [Constructor(DOMString type, optional PushSubscriptionChangeInit eventInitDict = {}), Exposed=ServiceWorker, SecureContext]
             interface PushSubscriptionChangeEvent : ExtendableEvent {
               readonly attribute PushSubscription? newSubscription;
               readonly attribute PushSubscription? oldSubscription;


### PR DESCRIPTION
This is part of heycam/webidl#758 (see also heycam/webidl#750)

The following tasks have been completed:

 * [X] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [X] Modified Web platform tests - gets picked up automatically.

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [X] [Gecko](https://bugzilla.mozilla.org/show_bug.cgi?id=1562680)

@beverloo, the underlying IDL change for Blink  is tracked at: https://bugs.chromium.org/p/chromium/issues/detail?id=948139


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/pull/308.html" title="Last updated on Jul 11, 2019, 5:36 AM UTC (3c20d60)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/308/800d866...3c20d60.html" title="Last updated on Jul 11, 2019, 5:36 AM UTC (3c20d60)">Diff</a>