### PR TITLE
fix: set to ArrayBuffer instead of BufferSource

### DIFF
--- a/index.html
+++ b/index.html
@@ -568,7 +568,7 @@
           following substeps:
           <ol>
             <li>If the <var>applicationServerKey</var> is provided as a {{DOMString}}, set its
-            value to a {{BufferSource}} containing the sequence of octets that result from decoding
+            value to an {{ArrayBuffer}} containing the sequence of octets that result from decoding
             <var>applicationServerKey</var> using the base64url encoding [[RFC7515]]. If decoding
             fails, reject promise with a {{DOMException}} whose name is "{{InvalidCharacterError}}"
             and terminate these steps.


### PR DESCRIPTION
Fixes #290 

I think this is an editorial mistake, not something we can really test for. 

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/pull/310.html" title="Last updated on Jul 15, 2019, 7:12 AM UTC (375c688)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/310/24673c5...375c688.html" title="Last updated on Jul 15, 2019, 7:12 AM UTC (375c688)">Diff</a>