### PR TITLE
Change PushSubscriptionChangeInit to PushSubscriptionChangeEventInit.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1220,7 +1220,7 @@
             <dfn>PushSubscriptionChangeEvent</dfn> Interface
           </h2>
           <pre class="idl" data-cite="service-workers">
-            [Constructor(DOMString type, optional PushSubscriptionChangeInit eventInitDict = {}), Exposed=ServiceWorker, SecureContext]
+            [Constructor(DOMString type, optional PushSubscriptionChangeEventInit eventInitDict = {}), Exposed=ServiceWorker, SecureContext]
             interface PushSubscriptionChangeEvent : ExtendableEvent {
               readonly attribute PushSubscription? newSubscription;
               readonly attribute PushSubscription? oldSubscription;
@@ -1235,12 +1235,12 @@
             initialized to.
           </p>
         </section>
-        <section data-dfn-for="PushSubscriptionChangeInit">
+        <section data-dfn-for="PushSubscriptionChangeEventInit">
           <h2>
-            <dfn>PushSubscriptionChangeInit</dfn> Interface
+            <dfn>PushSubscriptionChangeEventInit</dfn> Interface
           </h2>
           <pre class="idl" data-cite="service-workers">
-              dictionary PushSubscriptionChangeInit : ExtendableEventInit {
+              dictionary PushSubscriptionChangeEventInit : ExtendableEventInit {
                 PushSubscription newSubscription = null;
                 PushSubscription oldSubscription = null;
               };


### PR DESCRIPTION
This naming scheme is more consistent with other specs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rayankans/push-api/pull/312.html" title="Last updated on Jul 16, 2019, 1:32 PM UTC (8949cb9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/312/63d82a7...rayankans:8949cb9.html" title="Last updated on Jul 16, 2019, 1:32 PM UTC (8949cb9)">Diff</a>