### PR TITLE
Editorial: subscription unregistration happens magically

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,9 +282,11 @@
           <p>
             A <a>push subscription</a> is <a>deactivated</a> when its associated <a>service worker
             registration</a> is unregistered, though a <a>push subscription</a> MAY be
-            <a>deactivated</a> earlier. A <a>push subscription</a> is removed when the
-            <a data-cite="service-workers#clear-registration-algorithm">clear registration
-            algorithm</a> is run for the <a>service worker registration</a>.
+            <a>deactivated</a> earlier.
+          </p>
+          <p class="note">
+            A <a>push subscription</a> is removed when <a>service worker registration</a> is
+            cleared.
           </p>
         </section>
       </section>


### PR DESCRIPTION
See: https://github.com/w3c/ServiceWorker/issues/1410


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/pull/320.html" title="Last updated on Sep 7, 2019, 2:08 AM UTC (c21bd57)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/320/9355576...c21bd57.html" title="Last updated on Sep 7, 2019, 2:08 AM UTC (c21bd57)">Diff</a>