### PR TITLE
Switch to EpochTimeStamp

### DIFF
--- a/index.html
+++ b/index.html
@@ -760,7 +760,7 @@
 
         dictionary PushSubscriptionJSON {
           USVString endpoint;
-          EpochTimeStamp? expirationTime;
+          EpochTimeStamp? expirationTime = null;
           record&lt;DOMString, USVString&gt; keys;
         };
       </pre>

--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
         [Exposed=(Window,Worker), SecureContext]
         interface PushSubscription {
           readonly attribute USVString endpoint;
-          readonly attribute LegacyTimeStamp? expirationTime;
+          readonly attribute EpochTimeStamp? expirationTime;
           [SameObject] readonly attribute PushSubscriptionOptions options;
           ArrayBuffer? getKey(PushEncryptionKeyName name);
           Promise&lt;boolean&gt; unsubscribe();
@@ -760,7 +760,7 @@
 
         dictionary PushSubscriptionJSON {
           USVString endpoint;
-          LegacyTimeStamp? expirationTime;
+          EpochTimeStamp? expirationTime;
           record&lt;DOMString, USVString&gt; keys;
         };
       </pre>

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       };
     </script>
   </head>
-  <body data-cite="service-workers FILEAPI secure-contexts">
+  <body data-cite="service-workers FILEAPI secure-contexts hr-time">
     <section id="abstract">
       <p>
         The <cite>Push API</cite> enables sending of a <a>push message</a> to a web application via

--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
         [Exposed=(Window,Worker), SecureContext]
         interface PushSubscription {
           readonly attribute USVString endpoint;
-          readonly attribute DOMTimeStamp? expirationTime;
+          readonly attribute LegacyTimeStamp? expirationTime;
           [SameObject] readonly attribute PushSubscriptionOptions options;
           ArrayBuffer? getKey(PushEncryptionKeyName name);
           Promise&lt;boolean&gt; unsubscribe();
@@ -760,7 +760,7 @@
 
         dictionary PushSubscriptionJSON {
           USVString endpoint;
-          DOMTimeStamp? expirationTime;
+          LegacyTimeStamp? expirationTime;
           record&lt;DOMString, USVString&gt; keys;
         };
       </pre>


### PR DESCRIPTION
Closes #337 

DOMTimeStamp is giong away:
whatwg/webidl#1021

It was renamed EpochTimeStamp and is now part of HR-Time:
w3c/hr-time#124

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=1258800)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1497431)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/pull/338.html" title="Last updated on Oct 20, 2021, 5:54 AM UTC (adc7a44)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/338/a597111...adc7a44.html" title="Last updated on Oct 20, 2021, 5:54 AM UTC (adc7a44)">Diff</a>