### PR TITLE
Remove redudant secure context check

### DIFF
--- a/index.html
+++ b/index.html
@@ -556,9 +556,6 @@
         </li>
         <li>Return |promise| and continue the following steps asynchronously.
         </li>
-        <li>If the <a>current settings object</a> is not a [=secure context=], reject |promise|
-        with a {{DOMException}} whose name is {{"SecurityError"}} and terminate these steps.
-        </li>
         <li>If the |options| argument includes a non-null value for the
         {{PushSubscriptionOptions/applicationServerKey}} attribute, run the following sub-steps:
           <ol>


### PR DESCRIPTION
As the API declares WebIDL's `[SecureContext]` extended attribute, the API is only ever exposed in secure contexts. I think this assertion is redundant.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/pull/349.html" title="Last updated on Jun 1, 2022, 5:24 AM UTC (eeaddc5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/349/b78f1bb...eeaddc5.html" title="Last updated on Jun 1, 2022, 5:24 AM UTC (eeaddc5)">Diff</a>