### PR TITLE
Editorial: fix references to Fetch and Web Sockets

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,11 +115,10 @@
         Push messaging is best suited to occasions where there is not already an active
         communications channel established between <a>user agent</a> and web application. Sending
         <a>push messages</a> requires considerably more resources when compared with more direct
-        methods of communication such as [[[fetch]]] or <a data-cite=
-        "html/web-sockets.html#network">websockets</a>. <a>Push messages</a> usually have higher
-        latency than direct communications and they can also be subject to restrictions on use.
-        Most <a>push services</a> limit the size and quantity of <a>push messages</a> that can be
-        sent.
+        methods of communication such as the [[Fetch|Fetch API]] or [[Websockets|Web Sockets]].
+        <a>Push messages</a> usually have higher latency than direct communications and they can
+        also be subject to restrictions on use. Most <a>push services</a> limit the size and
+        quantity of <a>push messages</a> that can be sent.
       </p>
     </section>
     <section>


### PR DESCRIPTION
Web Sockets is now its own spec. Use an alias for Fetch API.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/pull/366.html" title="Last updated on Dec 11, 2023, 1:09 AM UTC (0ca7cd0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/366/d8401e8...0ca7cd0.html" title="Last updated on Dec 11, 2023, 1:09 AM UTC (0ca7cd0)">Diff</a>