### PR TITLE
Add bytes() method for reading bytes into a Uint8Array

### DIFF
--- a/index.html
+++ b/index.html
@@ -976,6 +976,7 @@
         interface PushMessageData {
           ArrayBuffer arrayBuffer();
           Blob blob();
+          Uint8Array bytes();
           any json();
           USVString text();
         };
@@ -992,6 +993,11 @@
       <p>
         The <dfn>blob()</dfn> method, when invoked, MUST return a {{Blob}} whose contents are
         |bytes| and |type| is not provided.
+      </p>
+      <p>
+        The <dfn>bytes()</dfn> method, when invoked, MUST return a {{Uint8Array}} backed by a
+        {{ArrayBuffer}} whose contents are |bytes|. Exceptions thrown during the creation of the
+        {{ArrayBuffer}} object are re-thrown.
       </p>
       <p data-cite="encoding">
         The <dfn>json()</dfn> method, when invoked, MUST return the result of invoking the initial


### PR DESCRIPTION
Closes #369

The Fetch API [is getting](https://github.com/whatwg/fetch/pull/1753) a `Uint8Array`-returning `bytes()` method alongside its existing `arrayBuffer()` method, following [the principle](https://github.com/w3ctag/design-principles/pull/480) that APIs should generally vend byte buffers as `Uint8Array`s.

This PR makes the same change for `PushMessageData`, which has its own distinct `arrayBuffer` method.

I'm assuming this is uncontroversial given the support from the three major implementations for doing this on `Body`, but I can open an issue and solicit explicit support separately if you'd prefer. I'll write tests if I get a signal that this is able to go forward.

It's unfortunate that `getKey` and `applicationServerKey` vend `ArrayBuffer`s instead of `Uint8Array`s, but it's too late to fix those now.

The following tasks have been completed:

 * [ ] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/46232)

Implementation commitment:
 
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [x] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1897871)
 * [X] WebKit (https://bugs.webkit.org/show_bug.cgi?id=274119)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/pull/370.html" title="Last updated on May 24, 2024, 4:21 AM UTC (0c6ac37)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/370/28f2a51...0c6ac37.html" title="Last updated on May 24, 2024, 4:21 AM UTC (0c6ac37)">Diff</a>