### PR TITLE
Set subscription's endpoint to the push endpoint more clearly

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,8 +229,8 @@
           </li>
           <li>When the <a>push subscription</a> request has completed successfully:
             <ol>
-              <li>Set |subscription|'s {{PushSubscription/endpoint}} attribute to the [=URL=]
-              provided by the <a>push subscription</a>.
+              <li>Set |subscription|'s {{PushSubscription/endpoint}} attribute to the
+              <a>push subscription</a>'s <a>push endpoint</a>.
               </li>
               <li>If provided by the <a>push subscription</a>, set |subscription|'s
               {{PushSubscription/expirationTime}}.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/pull/374.html" title="Last updated on Jul 8, 2024, 8:46 AM UTC (b1adecb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/374/a2f3730...b1adecb.html" title="Last updated on Jul 8, 2024, 8:46 AM UTC (b1adecb)">Diff</a>