### PR TITLE
Correct PushMessageData

### DIFF
--- a/index.html
+++ b/index.html
@@ -1004,8 +1004,8 @@
         <a>parsing JSON bytes to a JavaScript value</a> given <a>this</a>'s <a for=PushMessageData>bytes</a>.
       </p>
       <p data-cite="encoding">
-        The <dfn>text</dfn> method, when invoked, MUST return the result of running <a>UTF-8
-        decode</a> on |bytes|.
+        The <dfn>text()</dfn> method steps are to return the result of running <a>UTF-8 decode</a>
+        on <a>this</a>'s <a for=PushMessageData>bytes</a>.
       </p>
       <p>
         To <dfn>extract a byte sequence</dfn> from |object|, run these steps:

--- a/index.html
+++ b/index.html
@@ -982,30 +982,30 @@
         };
       </pre>
       <p>
-        <a>PushMessageData</a> objects have an associated <dfn data-dfn-for=PushMessageData>bytes</dfn> (a
+        <a>PushMessageData</a> objects have an associated <dfn>bytes</dfn> (a
         [=byte sequence=]), which is set on creation.
       </p>
       <p>
         The <dfn>arrayBuffer()</dfn> method steps are to return an {{ArrayBuffer}} whose contents
-        are <a>this</a>'s <a data-dfn-for=PushMessageData>bytes</a>. Exceptions thrown during the creation of
+        are [=this=]'s [=bytes=]. Exceptions thrown during the creation of
         the {{ArrayBuffer}} object are re-thrown.
       </p>
       <p>
         The <dfn>blob()</dfn> method steps are to return a new {{Blob}} object whose contents are
-        <a>this</a>'s <a data-dfn-for=PushMessageData>bytes</a>.
+        [=this=]'s [=bytes=].
       </p>
       <p>
         The <dfn>bytes()</dfn> method steps are to return a new {{Uint8Array}} backed by a
-        {{ArrayBuffer}} whose contents are <a>this</a>'s <a data-dfn-for=PushMessageData>bytes</a>. Exceptions thrown during the creation of the
+        {{ArrayBuffer}} whose contents are [=this=]'s [=bytes=]. Exceptions thrown during the creation of the
         {{ArrayBuffer}} object are re-thrown.
       </p>
       <p data-cite="encoding">
         The <dfn>json()</dfn> method steps are to return the result of
-        <a>parsing JSON bytes to a JavaScript value</a> given <a>this</a>'s <a data-dfn-for=PushMessageData>bytes</a>.
+        <a>parsing JSON bytes to a JavaScript value</a> given [=this=]'s [=bytes=].
       </p>
       <p data-cite="encoding">
         The <dfn>text()</dfn> method steps are to return the result of running <a>UTF-8 decode</a>
-        on <a>this</a>'s <a data-dfn-for=PushMessageData>bytes</a>.
+        on [=this=]'s [=bytes=].
       </p>
       <p>
         To <dfn>extract a byte sequence</dfn> from |object|, run these steps:

--- a/index.html
+++ b/index.html
@@ -982,30 +982,30 @@
         };
       </pre>
       <p>
-        <a>PushMessageData</a> objects have an associated <dfn for=PushMessageData>bytes</dfn> (a
+        <a>PushMessageData</a> objects have an associated <dfn data-dfn-for=PushMessageData>bytes</dfn> (a
         [=byte sequence=]), which is set on creation.
       </p>
       <p>
         The <dfn>arrayBuffer()</dfn> method steps are to return an {{ArrayBuffer}} whose contents
-        are <a>this</a>'s <a for=PushMessageData>bytes</a>. Exceptions thrown during the creation of
+        are <a>this</a>'s <a data-dfn-for=PushMessageData>bytes</a>. Exceptions thrown during the creation of
         the {{ArrayBuffer}} object are re-thrown.
       </p>
       <p>
         The <dfn>blob()</dfn> method steps are to return a new {{Blob}} object whose contents are
-        <a>this</a>'s <a for=PushMessageData>bytes</a>.
+        <a>this</a>'s <a data-dfn-for=PushMessageData>bytes</a>.
       </p>
       <p>
         The <dfn>bytes()</dfn> method steps are to return a new {{Uint8Array}} backed by a
-        {{ArrayBuffer}} whose contents are <a>this</a>'s <a for=PushMessageData>bytes</a>. Exceptions thrown during the creation of the
+        {{ArrayBuffer}} whose contents are <a>this</a>'s <a data-dfn-for=PushMessageData>bytes</a>. Exceptions thrown during the creation of the
         {{ArrayBuffer}} object are re-thrown.
       </p>
       <p data-cite="encoding">
         The <dfn>json()</dfn> method steps are to return the result of
-        <a>parsing JSON bytes to a JavaScript value</a> given <a>this</a>'s <a for=PushMessageData>bytes</a>.
+        <a>parsing JSON bytes to a JavaScript value</a> given <a>this</a>'s <a data-dfn-for=PushMessageData>bytes</a>.
       </p>
       <p data-cite="encoding">
         The <dfn>text()</dfn> method steps are to return the result of running <a>UTF-8 decode</a>
-        on <a>this</a>'s <a for=PushMessageData>bytes</a>.
+        on <a>this</a>'s <a data-dfn-for=PushMessageData>bytes</a>.
       </p>
       <p>
         To <dfn>extract a byte sequence</dfn> from |object|, run these steps:

--- a/index.html
+++ b/index.html
@@ -982,30 +982,29 @@
         };
       </pre>
       <p>
-        <a>PushMessageData</a> objects have an associated [=byte sequence=] set on creation, which
-        is `null` if there was no data in the <a>push message</a>.
+        <a>PushMessageData</a> objects have an associated <dfn for=PushMessageData>bytes</dfn> (a
+        [=byte sequence=]), which is set on creation.
       </p>
       <p>
-        The <dfn>arrayBuffer()</dfn> method, when invoked, MUST return an {{ArrayBuffer}} whose
-        contents are |bytes|. Exceptions thrown during the creation of the {{ArrayBuffer}} object
-        are re-thrown.
+        The <dfn>arrayBuffer()</dfn> method steps are to return an {{ArrayBuffer}} whose contents
+        are <a>this</a>'s <a for=PushMessageData>bytes</a>. Exceptions thrown during the creation of
+        the {{ArrayBuffer}} object are re-thrown.
       </p>
       <p>
-        The <dfn>blob()</dfn> method, when invoked, MUST return a {{Blob}} whose contents are
-        |bytes| and |type| is not provided.
+        The <dfn>blob()</dfn> method steps are to return a new {{Blob}} object whose contents are
+        <a>this</a>'s <a for=PushMessageData>bytes</a>.
       </p>
       <p>
-        The <dfn>bytes()</dfn> method, when invoked, MUST return a {{Uint8Array}} backed by a
-        {{ArrayBuffer}} whose contents are |bytes|. Exceptions thrown during the creation of the
+        The <dfn>bytes()</dfn> method steps are to return a new {{Uint8Array}} backed by a
+        {{ArrayBuffer}} whose contents are <a>this</a>'s <a for=PushMessageData>bytes</a>. Exceptions thrown during the creation of the
         {{ArrayBuffer}} object are re-thrown.
       </p>
       <p data-cite="encoding">
-        The <dfn>json()</dfn> method, when invoked, MUST return the result of invoking the initial
-        value of `JSON`.{{JSON/parse()}} with the result of running <a>utf-8 decode</a> on |bytes|
-        as argument. Re-throw any exceptions thrown by `JSON`.{{JSON/parse()}}.
+        The <dfn>json()</dfn> method steps are to return the result of
+        <a>parsing JSON bytes to a JavaScript value</a> given <a>this</a>'s <a for=PushMessageData>bytes</a>.
       </p>
       <p data-cite="encoding">
-        The <dfn>text</dfn> method, when invoked, MUST return the result of running <a>utf-8
+        The <dfn>text</dfn> method, when invoked, MUST return the result of running <a>UTF-8
         decode</a> on |bytes|.
       </p>
       <p>


### PR DESCRIPTION
Give PushMessageData a clear internal concept to hold the bytes and also make it clear that it cannot be null. None of the methods were prepared to handle it being null and nothing ever creates a PushMessageData object where it is null.

Partially addresses the concerns in #380 and fixes #381.

---

I installed tidy-html5 but that appears to not work. There are no instructions provided by this repository as to how to do formatting so I guess I'm fine with that happening in an automatic follow-up cleanup commit...

One thing that I'm not familiar with is ReSpec and how it does linking so that probably needs careful review here as I'm trying to introduce some new links.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/pull/382.html" title="Last updated on Jul 10, 2024, 12:13 PM UTC (cfed03d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/382/f30bf3d...cfed03d.html" title="Last updated on Jul 10, 2024, 12:13 PM UTC (cfed03d)">Diff</a>