### PR TITLE
Expose pushManager on Window

### DIFF
--- a/index.html
+++ b/index.html
@@ -1166,7 +1166,6 @@
             <li>Set |scope| to the result of running the [=basic URL parser=] given "`/`" and
             |global|'s <a>associated <code>Document</code></a>'s [=Document/URL=].
             </li>
-            <!-- Should the scope be validated here or do we trust the permission story to take care of that? Hmm. -->
           </ol>
         </li>
         <li>Otherwise:
@@ -1307,7 +1306,7 @@
         <li>Let |registration| be null.
         </li>
         <li>If [=this=]'s [=PushManager/service worker registration=] is null, then set
-        |windowScope| to the result of running the [=basic URL parser=] given "`/`" and [=this=]'s
+        |windowScope| to the result of running the [=basic URL parser=] given "`/`" and |global|'s
         <a>associated <code>Document</code></a>'s [=Document/URL=].
         </li>
         <li>Otherwise:

--- a/index.html
+++ b/index.html
@@ -1097,7 +1097,12 @@
         ServiceWorkerRegistration includes PushManagerAttribute;
       </pre>
       <p>
-        The <dfn>pushManager</dfn> attribute exposes a {{PushManager}}.
+        {{Window}} and {{ServiceWorkerRegistration}} objects have an associated {{PushManager}}
+        object.
+      </p>
+      <p>
+        The <dfn>pushManager</dfn> getter steps are to return [=this=]'s associated {{PushManager}}
+        object.
       </p>
       <p>
         On a {{Window}} object the {{PushManager}}'s [=PushManager/service worker registration=] is
@@ -1184,10 +1189,14 @@
             </p><!-- This doesn't really seem acceptable this day and age. -->
           </aside>
           <ol>
+            <li>If |scope| is failure or is a [=/URL=] whose [=url/scheme=] is not "`https`", then
+            [=queue a global task=] on the [=networking task source=] using |global| to [=reject=]
+            |promise| with a {{"NotAllowedError"}} {{DOMException}}.
+            </li>
             <li>If the |options| argument has a {{PushSubscriptionOptionsInit/userVisibleOnly}}
             value set to `false` and the user agent requires it to be `true`, [=queue a global
-            task=] on the [=networking task source=] using |global| to [=reject=] |promise|
-            {{"NotAllowedError"}} {{DOMException}}
+            task=] on the [=networking task source=] using |global| to [=reject=] |promise| with a
+            {{"NotAllowedError"}} {{DOMException}}.
             </li>
             <li>If the |options| argument does not include a non-null value for the
             {{PushSubscriptionOptionsInit/applicationServerKey}} member, and the <a>push

--- a/index.html
+++ b/index.html
@@ -699,9 +699,19 @@
         </h2>
         <p>
           A <dfn>push subscription</dfn> is a message delivery context established between the
-          <a>user agent</a> and the <a>push service</a> on behalf of a web application. Each
-          <a>push subscription</a> is associated with a <a>service worker registration</a> and a
-          <a>service worker registration</a> has at most one <a>push subscription</a>.
+          <a>user agent</a> and the <a>push service</a> on behalf of a web application.
+        </p>
+        <p>
+          A [=push subscription=] has an associated <dfn data-dfn-for=
+          "push subscription">scope</dfn>, which is a [=/URL=].
+        </p>
+        <p>
+          A [=push subscription=] is considered to have a <dfn data-dfn-for=
+          "push subscription">window-accessible scope</dfn> when its [=push subscription/scope=] is
+          a [=/list=] of [=list/size=] 1 and [=push subscription/scope=][0] is the empty string.
+        </p>
+        <p class="note">
+          I.e., the [=url/path=] component of the [=/URL=] serializes as "`/`".
         </p>
         <p>
           A <a>push subscription</a> has an associated <dfn>push endpoint</dfn>. It MUST be the
@@ -721,12 +731,9 @@
           creating the <a>push subscription</a>.
         </p>
         <p>
-          If the <a>user agent</a> has to change the keys for any reason, it MUST <a>fire the
-          "`pushsubscriptionchange`" event</a> with the <a>service worker registration</a>
-          associated with the <a>push subscription</a> as |registration|, a {{PushSubscription}}
-          instance representing the <a>push subscription</a> having the old keys as
-          |oldSubscription| and a {{PushSubscription}} instance representing the <a>push
-          subscription</a> having the new keys as |newSubscription|.
+          If the <a>user agent</a> has to change the keys of a [=push subscription=] for any reason
+          and the [=push subscription=]'s [=associated service worker registration=] is non-null,
+          it MUST [=refresh=] the [=push subscription=].
         </p>
         <p>
           To <dfn>create a push subscription</dfn>, given an {{PushSubscriptionOptionsInit}}
@@ -771,17 +778,41 @@
         </ol>
         <section>
           <h2>
-            Subscription Refreshes
+            Relationship to service worker registrations
+          </h2>
+          <p>
+            A [=push subscription=]'s <dfn>associated service worker registration</dfn> is the
+            [=service worker registration=] whose [=service worker registration/scope URL=]
+            [=URL/equals=] the [=push subscription=]'s [=push subscription/scope=], if any;
+            otherwise null.
+          </p>
+          <p class="note">
+            A [=push subscription=]'s [=associated service worker registration=] can only be null
+            when it has a [=push subscription/window-accessible scope=].
+          </p>
+          <p>
+            And vice versa, a [=service worker registration=]'s <dfn>associated push
+            subscription</dfn> is the [=push subscription=] whose [=push subscription/scope=]
+            [=URL/equals=] the [=service worker registration=]'s [=service worker
+            registration/scope URL=], if any; otherwise null.
+          </p>
+        </section>
+        <section>
+          <h2>
+            Subscription refreshes
           </h2>
           <p>
             A <a>user agent</a> or <a>push service</a> MAY choose to <dfn>refresh</dfn> a <a>push
-            subscription</a> at any time, for example because it has reached a certain age.
+            subscription</a> whose [=associated service worker registration=] is non-null at any
+            time, for example because it has reached a certain age.
           </p>
           <p>
             When this happens, the <a>user agent</a> MUST run the steps to <a>create a push
             subscription</a> given the <a>PushSubscriptionOptions</a> that were provided for
-            creating the current <a>push subscription</a>. The new <a>push subscription</a> MUST
-            have a key pair that's different from the original subscription.
+            creating the current <a>push subscription</a>, and set the new [=push subscription=]'s
+            [=push subscription/scope=] to the original subscription's [=push subscription/scope=].
+            The new <a>push subscription</a> MUST have a key pair that's different from the
+            original subscription.
           </p>
           <p>
             When successful, <a>user agent</a> then MUST <a>fire the "`pushsubscriptionchange`"
@@ -808,7 +839,7 @@
         </section>
         <section>
           <h2>
-            Subscription Deactivation
+            Subscription deactivation
           </h2>
           <p>
             When a <a>push subscription</a> is <dfn data-lt="deactivate">deactivated</dfn>, both
@@ -817,13 +848,13 @@
             delivered.
           </p>
           <p>
-            A <a>push subscription</a> is <a>deactivated</a> when its associated <a>service worker
-            registration</a> is unregistered, though a <a>push subscription</a> MAY be
-            <a>deactivated</a> earlier.
+            A <a>push subscription</a> without a [=push subscription/window-accessible scope=] is
+            <a>deactivated</a> when its associated <a>service worker registration</a> is
+            unregistered, though a <a>push subscription</a> MAY be <a>deactivated</a> earlier.
           </p>
           <p class="note">
-            A <a>push subscription</a> is removed when <a>service worker registration</a> is
-            cleared.
+            A <a>push subscription</a> without a [=push subscription/window-accessible scope=] is
+            removed when <a>service worker registration</a> is cleared.
           </p>
         </section>
       </section>
@@ -1049,23 +1080,23 @@
       </section>
     </section>
     <section data-dfn-for="ServiceWorkerRegistration">
-      <h2>
-        Extensions to the `ServiceWorkerRegistration` Interface
+      <h2 id="extensions-to-the-serviceworkerregistration-interface">
+        `PushManagerAttribute` mixin
       </h2>
       <p>
-        The Service Worker specification defines a {{ServiceWorkerRegistration}} interface
-        [[SERVICE-WORKERS]], which this specification extends.
+        This specifications extends the {{Window}} and {{ServiceWorkerRegistration}} objects
+        through the {{PushManagerAttribute}} mixin. [[HTML]] [[SERVICE-WORKERS]]
       </p>
-      <pre class="idl" data-cite="SERVICE-WORKERS">
+      <pre class="idl" data-cite="HTML SERVICE-WORKERS">
         [SecureContext]
-        partial interface ServiceWorkerRegistration {
+        interface mixin PushManagerAttribute {
           readonly attribute PushManager pushManager;
         };
+        Window includes PushManagerAttribute;
+        ServiceWorkerRegistration includes PushManagerAttribute;
       </pre>
       <p>
-        The <dfn>pushManager</dfn> attribute exposes a {{PushManager}}, which has an associated
-        <a>service worker registration</a> represented by the {{ServiceWorkerRegistration}} on
-        which the attribute is exposed.
+        The <dfn>pushManager</dfn> attribute exposes a {{PushManager}}.
       </p>
     </section>
     <section data-dfn-for="PushManager">
@@ -1107,7 +1138,23 @@
         </li>
         <li>Let |global| be [=this=]' [=relevant global object=].
         </li>
-        <li>Return |promise| and continue [=in parallel=].
+        <li>Let |scope| be null.
+        </li>
+        <li>Let |registration| be null.
+        </li>
+        <li>If [=this=] is a {{Window}} object, then set |scope| to the result of running the
+        [=basic URL parser=] given "`/`" and |global|'s <a>associated <code>Document</code></a>'s
+        [=Document/URL=].
+        </li>
+        <li>Otherwise:
+          <ol>
+            <li>[=/Assert=]: [=this=] is a {{ServiceWorkerRegistration}} object.
+            </li>
+            <li>Set |registration| to [=this=]'s associated [=service worker registration=].
+            </li>
+          </ol>
+        </li>
+        <li>Run these steps [=in parallel=]:
           <aside class="note" title="Validation order can vary across user agents">
             <p>
               Because of implementation-specific reasons, user agents are known to do some of the
@@ -1117,80 +1164,106 @@
               don't believe this affects interoperability of implementations or web applications.
             </p>
           </aside>
-        </li>
-        <li>If the |options| argument has a {{PushSubscriptionOptionsInit/userVisibleOnly}} value
-        set to `false` and the user agent requires it to be `true`, [=queue a global task=] on the
-        [=networking task source=] using |global| to [=reject=] |promise| {{"NotAllowedError"}}
-        {{DOMException}}
-        </li>
-        <li>If the |options| argument does not include a non-null value for the
-        {{PushSubscriptionOptionsInit/applicationServerKey}} member, and the <a>push service</a>
-        requires one to be given, [=queue a global task=] on the [=networking task source=] using
-        |global| to [=reject=] |promise| with a {{"NotSupportedError"}} {{DOMException}}.
-        </li>
-        <li>If the |options| argument includes a non-null value for the
-        {{PushSubscriptionOptions/applicationServerKey}} attribute, run the following sub-steps:
           <ol>
-            <li>If |options|'s {{PushSubscriptionOptionsInit/applicationServerKey}} is a
-            {{DOMString}}, set its value to an {{ArrayBuffer}} containing the sequence of octets
-            that result from decoding |options|'s
-            {{PushSubscriptionOptionsInit/applicationServerKey}} using the base64url encoding
-            [[RFC7515]].
+            <li>If the |options| argument has a {{PushSubscriptionOptionsInit/userVisibleOnly}}
+            value set to `false` and the user agent requires it to be `true`, [=queue a global
+            task=] on the [=networking task source=] using |global| to [=reject=] |promise|
+            {{"NotAllowedError"}} {{DOMException}}
             </li>
-            <li>If decoding fails, [=queue a global task=] on the [=networking task source=] using
-            |global| to [=reject=] |promise| with an {{"InvalidCharacterError"}} {{DOMException}}
-            and terminate these steps.
+            <li>If the |options| argument does not include a non-null value for the
+            {{PushSubscriptionOptionsInit/applicationServerKey}} member, and the <a>push
+            service</a> requires one to be given, [=queue a global task=] on the [=networking task
+            source=] using |global| to [=reject=] |promise| with a {{"NotSupportedError"}}
+            {{DOMException}}.
             </li>
-            <li>Ensure that |options|'s {{PushSubscriptionOptionsInit/applicationServerKey}}
-            describes a valid point on the P-256 curve. If its value is invalid, [=queue a global
-            task=] on the [=networking task source=] using |global| to [=reject=] |promise| with an
-            {{"InvalidAccessError"}} {{DOMException}} and terminate these steps.
+            <li>If the |options| argument includes a non-null value for the
+            {{PushSubscriptionOptions/applicationServerKey}} attribute:
+              <ol>
+                <li>If |options|'s {{PushSubscriptionOptionsInit/applicationServerKey}} is a
+                {{DOMString}}, set its value to an {{ArrayBuffer}} containing the sequence of
+                octets that result from decoding |options|'s
+                {{PushSubscriptionOptionsInit/applicationServerKey}} using the base64url encoding
+                [[RFC7515]].
+                </li>
+                <li>If decoding fails, [=queue a global task=] on the [=networking task source=]
+                using |global| to [=reject=] |promise| with an {{"InvalidCharacterError"}}
+                {{DOMException}} and terminate these steps.
+                </li>
+                <li>Ensure that |options|'s {{PushSubscriptionOptionsInit/applicationServerKey}}
+                describes a valid point on the P-256 curve. If its value is invalid, [=queue a
+                global task=] on the [=networking task source=] using |global| to [=reject=]
+                |promise| with an {{"InvalidAccessError"}} {{DOMException}} and terminate these
+                steps.
+                </li>
+              </ol>
+            </li>
+            <li>Let |subscription| be null.
+            </li>
+            <li>If |scope| is non-null:
+              <ol>
+                <li>If there is a [=push subscription=] with a [=push
+                subscription/window-accessible scope=] whose [=push subscription/scope=]
+                [=URL/equals=] |scope|, then set |subscription| to that [=push subscription=].
+                </li>
+              </ol>
+            </li>
+            <li>Otherwise:
+              <ol>
+                <li>[=/Assert=]: |registration| is non-null.
+                </li>
+                <li>If |registration|'s [=service worker registration/active worker=] is null,
+                [=queue a global task=] on the [=networking task source=] using |global| to
+                [=reject=] |promise| with an {{"InvalidStateError"}} {{DOMException}} and terminate
+                these steps.
+                </li>
+                <li>If |registration|'s [=associated push subscription=] is non-null, then set
+                |subscription| to |registration|'s [=associated push subscription=].
+                </li>
+                <li>Set |scope| to |registration|'s [=service worker registration/scope URL=].
+                </li>
+              </ol>
+            </li>
+            <li>Let |permission| be [=request permission to use=] "push".
+            </li>
+            <li>If |permission| is {{PermissionState/"denied"}}, [=queue a global task=] on the
+            [=user interaction task source=] using |global| to [=reject=] |promise| with a
+            {{"NotAllowedError"}} {{DOMException}} and terminate these steps.
+            </li>
+            <li>If |subscription| is non-null:
+              <ol>
+                <li>If there is an error with |subscription|, then [=queue a global task=] on the
+                [=networking task source=] using |global| to [=reject=] |promise| with an
+                {{"AbortError"}} {{DOMException}} and terminate these steps.
+                </li>
+                <li>Compare the |options| argument with the `options` attribute of |subscription|.
+                The contents of {{BufferSource}} values are compared for equality rather than
+                [=ECMAScript/reference record|reference=].
+                </li>
+                <li>If any attribute on |options| contains a different value to that stored for
+                |subscription|, then [=queue a global task=] on the [=networking task source=]
+                using |global| to [=reject=] |promise| with an {{"InvalidStateError"}}
+                {{DOMException}} and terminate these steps.
+                </li>
+                <li>[=Queue a global task=] on the [=networking task source=] using |global| to
+                [=resolve=] |promise| with |subscription| and terminate these steps.
+                </li>
+              </ol>
+            </li>
+            <li>[=/Assert=]: |subscription| is null and |scope| is a [=/URL=].
+            </li>
+            <li>Set |subscription| to the result of trying to [=create a push subscription=] with
+            |options|. If creating the subscription [=exception/throws=] an [=exception=], [=queue
+            a global task=] on the [=networking task source=] using |global| to [=reject=]
+            |promise| with a that [=exception=] and terminate these steps.
+            </li>
+            <li>Set |subscription|'s [=push subscription/scope=] to |scope|.
+            </li>
+            <li>[=Queue a global task=] on the [=networking task source=] using |global| to
+            [=resolve=] |promise| with a {{PushSubscription}} corresponding to |subscription|.
             </li>
           </ol>
         </li>
-        <li>Let |registration:ServiceWorkerRegistration| be [=this=]'s associated <a>service worker
-        registration</a>.
-        </li>
-        <li>If |registration|'s [=service worker registration/active worker=] is null, [=queue a
-        global task=] on the [=networking task source=] using |global| to [=reject=] |promise| with
-        an {{"InvalidStateError"}} {{DOMException}} and terminate these steps.
-        </li>
-        <li>Let |permission| be [=request permission to use=] "push".
-        </li>
-        <li>If |permission| is {{PermissionState/"denied"}}, [=queue a global task=] on the [=user
-        interaction task source=] using |global| to [=reject=] |promise| with a
-        {{"NotAllowedError"}} {{DOMException}} and terminate these steps.
-        </li>
-        <li>If |registration| has a <a>push subscription</a>:
-          <ol>
-            <li>Let |subscription| be the result of obtaining |registration|'s <a>push
-            subscription</a>. If there is an error, [=queue a global task=] on the [=networking
-            task source=] using |global| to [=reject=] |promise| with an {{"AbortError"}}
-            {{DOMException}} and terminate these steps.
-            </li>
-            <li>Compare the |options| argument with the `options` attribute of |subscription|. The
-            contents of {{BufferSource}} values are compared for equality rather than
-            [=ECMAScript/reference record|reference=].
-            </li>
-            <li>If any attribute on |options| contains a different value to that stored for
-            |subscription|, then [=queue a global task=] on the [=networking task source=] using
-            |global| to [=reject=] |promise| with an {{"InvalidStateError"}} {{DOMException}} and
-            terminate these steps.
-            </li>
-            <li>When the request has been completed, [=queue a global task=] on the [=networking
-            task source=] using |global| to [=resolve=] |promise| with |subscription| and terminate
-            these steps.
-            </li>
-          </ol>
-        </li>
-        <li>Let |subscription| be the result of trying to [=create a push subscription=] with
-        |options|. If creating the subscription [=exception/throws=] an [=exception=], [=queue a
-        global task=] on the [=networking task source=] using |global| to [=reject=] |promise| with
-        a that [=exception=] and terminate these these steps.
-        </li>
-        <li>Otherwise, [=queue a global task=] on the [=networking task source=] using |global| to
-        [=resolve=] |promise| with a {{PushSubscription}} providing the details of the new
-        |subscription|.
+        <li>Return |promise|.
         </li>
       </ol>
       <p>
@@ -1200,17 +1273,54 @@
       <ol>
         <li>Let |promise| be <a>a new promise</a>.
         </li>
-        <li>Return |promise| and continue the following steps asynchronously.
+        <li>Let |global| be [=this=]'s [=relevant global object=].
         </li>
-        <li>If the <a>Service Worker</a> is not subscribed, resolve |promise| with null.
+        <li>Let |windowScope| be null.
         </li>
-        <li>Retrieve the <a>push subscription</a> associated with the <a>Service Worker</a>.
+        <li>Let |registration| be null.
         </li>
-        <li>If there is an error, reject |promise| with a {{DOMException}} whose name is
-        {{"AbortError"}} and terminate these steps.
+        <li>If [=this=] is a {{Window}} object, then set |windowScope| to the result of running the
+        [=basic URL parser=] given "`/`" and [=this=]'s <a>associated <code>Document</code></a>'s
+        [=Document/URL=].
         </li>
-        <li>When the request has been completed, resolve |promise| with a {{PushSubscription}}
-        providing the details of the retrieved <a>push subscription</a>.
+        <li>Otherwise:
+          <ol>
+            <li>[=/Assert=]: [=this=] is a {{ServiceWorkerRegistration}} object.
+            </li>
+            <li>Set |registration| to [=this=]'s associated [=service worker registration=].
+            </li>
+          </ol>
+        </li>
+        <li>Run these steps [=/in parallel=]:
+          <ol>
+            <li>Let |subscription| be null.
+            </li>
+            <li>If |windowScope| is non-null:
+              <ol>
+                <li>If there is a [=push subscription=] whose [=push subscription/scope=] is
+                |windowScope|, then set |subscription| to that [=push subscription=].
+                </li>
+              </ol>
+            </li>
+            <li>Otherwise:
+              <ol>
+                <li>[=/Assert=]: |registration| is non-null.
+                </li>
+                <li>If |registration|'s [=associated push subscription=] is non-null, then set
+                |subscription| to |registration|'s [=associated push subscription=].
+                </li>
+              </ol>
+            </li>
+            <li>If |subscription| is null, then resolve |promise| with null.
+            </li>
+            <li>If there is an error with |subscription|, reject |promise| with a {{DOMException}}
+            whose name is {{"AbortError"}} and terminate these steps.
+            </li>
+            <li>Resolve |promise| with a {{PushSubscription}} corresponding to |subscription|.
+            </li>
+          </ol>
+        </li>
+        <li>Return |promise|.
         </li>
       </ol>
       <p>

--- a/index.html
+++ b/index.html
@@ -707,8 +707,9 @@
         </p>
         <p>
           A [=push subscription=] is considered to have a <dfn data-dfn-for=
-          "push subscription">window-accessible scope</dfn> when its [=push subscription/scope=] is
-          a [=/list=] of [=list/size=] 1 and [=push subscription/scope=][0] is the empty string.
+          "push subscription">window-accessible scope</dfn> when its [=push subscription/scope=]'s
+          [=url/path=] is a [=/list=] of [=list/size=] 1 and [=push subscription/scope=]'s
+          [=url/path=][0] is the empty string.
         </p>
         <p class="note">
           I.e., the [=url/path=] component of the [=/URL=] serializes as "`/`".
@@ -1098,6 +1099,15 @@
       <p>
         The <dfn>pushManager</dfn> attribute exposes a {{PushManager}}.
       </p>
+      <p>
+        On a {{Window}} object the {{PushManager}}'s [=PushManager/service worker registration=] is
+        null.
+      </p>
+      <p>
+        On a {{ServiceWorkerRegistration}} object the {{PushManager}}'s [=PushManager/service
+        worker registration=] is the <a>service worker registration</a> represented by the
+        {{ServiceWorkerRegistration}} object.
+      </p>
     </section>
     <section data-dfn-for="PushManager">
       <h2>
@@ -1117,6 +1127,10 @@
         };
       </pre>
       <p>
+        A {{PushManager}} has an associated <dfn data-dfn-for="PushManager">service worker
+        registration</dfn> which is null or a <a>service worker registration</a>.
+      </p>
+      <p>
         The <dfn>supportedContentEncodings</dfn> attribute exposes the sequence of supported
         content codings that can be used to encrypt the payload of a <a>push message</a>. A content
         coding is indicated using the <a>Content-Encoding</a> header field when requesting the
@@ -1131,26 +1145,31 @@
         `subscribe()` method
       </h3>
       <p>
-        The <dfn>subscribe()</dfn> method when invoked MUST run the following steps:
+        The <dfn>subscribe()</dfn> method steps are:
       </p>
       <ol class="algorithm">
         <li>Let |promise| be [=a new promise=].
         </li>
-        <li>Let |global| be [=this=]' [=relevant global object=].
+        <li>Let |global| be [=this=]'s [=relevant global object=].
         </li>
         <li>Let |scope| be null.
         </li>
         <li>Let |registration| be null.
         </li>
-        <li>If [=this=] is a {{Window}} object, then set |scope| to the result of running the
-        [=basic URL parser=] given "`/`" and |global|'s <a>associated <code>Document</code></a>'s
-        [=Document/URL=].
+        <li>If [=this=]'s [=PushManager/service worker registration=] is null:
+          <ol>
+            <li>Set |scope| to the result of running the [=basic URL parser=] given "`/`" and
+            |global|'s <a>associated <code>Document</code></a>'s [=Document/URL=].
+            </li>
+            <!-- Should the scope be validated here or do we trust the permission story to take care of that? Hmm. -->
+          </ol>
         </li>
         <li>Otherwise:
           <ol>
-            <li>[=/Assert=]: [=this=] is a {{ServiceWorkerRegistration}} object.
+            <li>[=/Assert=]: [=this=]'s [=PushManager/service worker registration=] is a [=service
+            worker registration=].
             </li>
-            <li>Set |registration| to [=this=]'s associated [=service worker registration=].
+            <li>Set |registration| to [=this=]'s [=PushManager/service worker registration=].
             </li>
           </ol>
         </li>
@@ -1162,7 +1181,7 @@
               {{PushSubscriptionOptionsInit/userVisibleOnly}} is allowed after validating the
               {{PushSubscriptionOptionsInit/applicationServerKey}}, and vice versa). However, we
               don't believe this affects interoperability of implementations or web applications.
-            </p>
+            </p><!-- This doesn't really seem acceptable this day and age. -->
           </aside>
           <ol>
             <li>If the |options| argument has a {{PushSubscriptionOptionsInit/userVisibleOnly}}
@@ -1267,8 +1286,7 @@
         </li>
       </ol>
       <p>
-        The <dfn data-dfn-for="PushManager">getSubscription</dfn> method when invoked MUST run the
-        following steps:
+        The <dfn data-dfn-for="PushManager">getSubscription()</dfn> method steps are:
       </p>
       <ol>
         <li>Let |promise| be <a>a new promise</a>.
@@ -1279,15 +1297,16 @@
         </li>
         <li>Let |registration| be null.
         </li>
-        <li>If [=this=] is a {{Window}} object, then set |windowScope| to the result of running the
-        [=basic URL parser=] given "`/`" and [=this=]'s <a>associated <code>Document</code></a>'s
-        [=Document/URL=].
+        <li>If [=this=]'s [=PushManager/service worker registration=] is null, then set
+        |windowScope| to the result of running the [=basic URL parser=] given "`/`" and [=this=]'s
+        <a>associated <code>Document</code></a>'s [=Document/URL=].
         </li>
         <li>Otherwise:
           <ol>
-            <li>[=/Assert=]: [=this=] is a {{ServiceWorkerRegistration}} object.
+            <li>[=/Assert=]: [=this=]'s [=PushManager/service worker registration=] is a [=service
+            worker registration=].
             </li>
-            <li>Set |registration| to [=this=]'s associated [=service worker registration=].
+            <li>Set |registration| to [=this=]'s [=PushManager/service worker registration=].
             </li>
           </ol>
         </li>
@@ -1749,20 +1768,34 @@
           it MUST run the following steps.
         </p>
         <ol>
-          <li>Let |registration| be the <a>service worker registration</a> corresponding to the <a>
-            push message</a>.
+          <li>
+            <p>
+              Let |subscription| be the active <a>push subscription</a> corresponding to the
+              <a>push message</a>.
+            </p>
           </li>
-          <li>If |registration| is not found, abort these steps.
+          <li>
+            <p>
+              Let |registration| be |subscription|'s [=push subscription/associated service worker
+              registration=].
+            </p>
           </li>
-          <li>Let |subscription| be the active <a>push subscription</a> for |registration|.
+          <li>
+            <p>
+              Let |bytes| be null.
+            </p>
           </li>
-          <li>Let |bytes| be null.
-          </li>
-          <li>If the <a>push message</a> contains a payload:
+          <li>
+            <p>
+              If the <a>push message</a> contains a payload:
+            </p>
             <ol>
-              <li>Decrypt the <a>push message</a>'s payload using the private key from the key pair
-              associated with |subscription| and the process described in [[RFC8291]]. Set |bytes|
-              to the resulting [=/byte sequence=].
+              <li>
+                <p>
+                  Decrypt the <a>push message</a>'s payload using the private key from the key pair
+                  associated with |subscription| and the process described in [[RFC8291]]. Set
+                  |bytes| to the resulting [=/byte sequence=].
+                </p>
               </li>
               <li>
                 <p>
@@ -1784,7 +1817,7 @@
             <ol>
               <li>
                 <p>
-                  Let |baseURL| be |registration|'s [=service worker registration/scope URL=].
+                  Let |baseURL| be |subscription|'s [=push subscription/scope=].
                 </p>
               </li>
               <li>
@@ -1828,7 +1861,7 @@
                   <li>
                     <p>
                       If |declarativeResult|'s [=declarative push message parser result/mutable=]
-                      is true:
+                      is true and |registration| is non-null:
                     </p>
                     <ol>
                       <li>
@@ -1861,6 +1894,11 @@
                 </ol>
               </li>
             </ol>
+          </li>
+          <li>
+            <p>
+              If |registration| is null, then abort these steps.
+            </p>
           </li>
           <li>
             <p>


### PR DESCRIPTION
This is part of the Declarative Web Push initiative (see #360) and mainly makes sense when that is supported, although could be independently supported in theory.

This makes window.pushManager work by making push subscriptions tied to a scope rather than a service worker registration. Most often push subscriptions remain 1:1 with service worker registrations, but the scope whose serialized path is "/" is treated specially from now on and can exist independently.

This obsoletes #368.

The following tasks have been completed:

 * [x] Modified Web platform tests (link to pull request): N/A, except IDL coverage

Implementer support:
 
 * [ ] Chromium 
 * [x] Gecko
 * [x] WebKit


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/pull/393.html" title="Last updated on Sep 8, 2025, 2:46 PM UTC (b0bfe7b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/393/f28f781...b0bfe7b.html" title="Last updated on Sep 8, 2025, 2:46 PM UTC (b0bfe7b)">Diff</a>