### PR TITLE
Meta: address xref issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -996,8 +996,8 @@
         creation of the {{ArrayBuffer}} object are re-thrown.
       </p>
       <p data-cite="encoding">
-        The <dfn>json()</dfn> method steps are to return the result of <a>parsing JSON bytes to a
-        JavaScript value</a> given [=this=]'s [=bytes=].
+        The <dfn>json()</dfn> method steps are to return the result of [=parse JSON bytes to a
+        JavaScript value|parsing JSON bytes to a JavaScript value=] given [=this=]'s [=bytes=].
       </p>
       <p data-cite="encoding">
         The <dfn>text()</dfn> method steps are to return the result of running <a>UTF-8 decode</a>


### PR DESCRIPTION
Apparently ReSpec does not support this.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/pull/394.html" title="Last updated on Nov 19, 2024, 12:32 PM UTC (8209b42)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/394/53fc465...8209b42.html" title="Last updated on Nov 19, 2024, 12:32 PM UTC (8209b42)">Diff</a>