### PR TITLE
Allow firing pushsubscriptionchange on all permission changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,6 +342,22 @@
           `{name: "push", userVisibleOnly: false}` is [=PermissionDescriptor/stronger than=]
           `{name: "push", userVisibleOnly: true}`.
         </p>
+        <p>
+          When the permission state changes (for example, it is revoked or re-granted), the <a>user
+          agent</a> MAY <a>fire the "`pushsubscriptionchange`" event</a> for subscriptions created
+          with that permission, with the <a>service worker registration</a> associated with
+          the <a>push subscription</a> as |registration|, a {{PushSubscription}} instance
+          representing the <a>push subscription</a> which should not be used anymore (for example,
+          because it has been or it is being <a>deactivated</a>) or `null` if it is not available
+          anymore as |oldSubscription|, and a {{PushSubscription}} representing a new valid <a>push
+          subscription</a> or `null` if none could be created as |newSubscription|.
+        </p>
+        <p class="note">
+          A permission state change can happen for a number of reasons, some of which are likely
+          vendor specific. Because of that, this specification does not mandate firing the
+          <a>pushsubscriptionchange</a> event in all possible cases, and instead leaves it up to
+          the <a>user agent</a> to decide when it is appropriate to do so.
+        </p>
       </section>
     </section>
     <section>


### PR DESCRIPTION
Closes #236

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)
 No, because this allows and does not mandate firing the event. Moreover, WPT support for changing permissions is kind of limited at the moment.

Implementation commitment:
 
 * [x] Chromium (https://issues.chromium.org/issues/407523313)
 * [x] Gecko (This is implemented already, see https://bugzilla.mozilla.org/show_bug.cgi?id=1497429)
 * [ ] WebKit (unknown)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/antosart/push-api/pull/400.html" title="Last updated on Apr 22, 2025, 11:22 AM UTC (1bd228f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/400/fe3f8ff...antosart:1bd228f.html" title="Last updated on Apr 22, 2025, 11:22 AM UTC (1bd228f)">Diff</a>