### PR TITLE
Add app badge to Declarative Web Push

### DIFF
--- a/index.html
+++ b/index.html
@@ -1779,11 +1779,26 @@
                       given |notification|.
                     </p>
                   </li>
-                  <li>
+                  <li data-cite="appmanifest">
                     <p>
-                      If |appBadgeSet| is false, then <a href=
-                      "https://github.com/w3c/badging/issues/111">w3c/badging #111</a>...
+                      If |appBadgeSet| is false and the web application associated with the <a>push
+                      subscription</a> is an [=installed web application=]:
                     </p>
+                    <ol>
+                      <li>
+                        <p>
+                          Let |identity| be the web application's [=installed web
+                          application/identity=] [=/URL=].
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          [=Set the application badge for installed web application=] given
+                          |identity| and |declarativeResult|'s [=declarative push message parser
+                          result/app badge=].
+                        </p>
+                      </li>
+                    </ol>
                   </li>
                   <li>
                     <p>

--- a/index.html
+++ b/index.html
@@ -393,13 +393,25 @@
               </dl>
             </dd>
             <dt>
+              <code>app_badge</code>
+            </dt>
+            <dd>
+              <p>
+                A [=/64-bit unsigned integer=].
+              </p>
+              <p class="note">
+                Platform conventions are likely to impose a lower limit with regards to what is
+                displayed to the end user. [[BADGING]]
+              </p>
+            </dd>
+            <dt>
               <code>mutable</code>
             </dt>
             <dd>
               <p>
                 A boolean. When true causes a <code>push</code> event to be dispatched to a service
-                worker (if any) containing the {{Notification}} object described by the
-                <a>declarative push message</a>.
+                worker (if any) containing the {{Notification}} object and app badge number (if
+                any) described by the <a>declarative push message</a>.
               </p>
             </dd>
           </dl>
@@ -411,7 +423,8 @@
           <p>
             A <dfn>declarative push message parser result</dfn> is a [=/tuple=] consisting of a
             <dfn data-dfn-for="declarative push message parser result">notification</dfn> (a
-            [=/notification=]) and a <dfn data-dfn-for=
+            [=/notification=]), an <dfn data-dfn-for="declarative push message parser result">app
+            badge</dfn> (null or an integer), and a <dfn data-dfn-for=
             "declarative push message parser result">mutable</dfn> (a boolean).
           </p>
           <p>
@@ -675,6 +688,18 @@
             </li>
             <li>
               <p>
+                Let <var>appBadge</var> be null.
+              </p>
+            </li>
+            <li>
+              <p>
+                If <var>message</var>["`app_badge`"] [=map/exists=] and
+                <var>message</var>["`app_badge`"] is a [=/64-bit unsigned integer=], then set
+                <var>appBadge</var> to <var>message</var>["`app_badge`"].
+              </p><!-- unsigned long long in Web IDL -->
+            </li>
+            <li>
+              <p>
                 Let <var>mutable</var> be false.
               </p>
             </li>
@@ -687,7 +712,7 @@
             </li>
             <li>
               <p>
-                Return (<var>notification</var>, <var>mutable</var>).
+                Return (<var>notification</var>, <var>appBadge</var>, <var>mutable</var>).
               </p>
             </li>
           </ol>
@@ -1598,11 +1623,13 @@
               constructor(DOMString type, optional PushEventInit eventInitDict = {});
               readonly attribute PushMessageData? data;
               readonly attribute Notification? notification;
+              readonly attribute unsigned long long? appBadge;
             };
 
             dictionary PushEventInit : ExtendableEventInit {
               PushMessageDataInit? data = null;
               Notification? notification = null;
+              unsigned long long? appBadge = null;
             };
 
             typedef (BufferSource or USVString) PushMessageDataInit;
@@ -1628,6 +1655,9 @@
         </p>
         <p>
           The <dfn>notification</dfn> attribute must return the value it was initialized with.
+        </p>
+        <p>
+          The <dfn>appBadge</dfn> attribute must return the value it was initialized with.
         </p>
       </section>
       <section>
@@ -1717,6 +1747,11 @@
                   </li>
                   <li>
                     <p>
+                      Let |appBadgeSet| be false.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
                       If |declarativeResult|'s [=declarative push message parser result/mutable=]
                       is true:
                     </p>
@@ -1724,14 +1759,16 @@
                       <li>
                         <p>
                           Let |result| be the result of [=fire a push event|firing a push event=]
-                          given |registration|, null, and a new {{Notification}} object
-                          representing |notification|.
+                          given |registration|, null, a new {{Notification}} object representing
+                          |notification|, and |declarativeResult|'s [=declarative push message
+                          parser result/app badge=].
                         </p>
                       </li>
                       <li>
                         <p>
                           If |result| is not failure, then set |notificationShown| to |result|'s
-                          [=push event result/notification shown=].
+                          [=push event result/notification shown=] and |appBadgeSet| to |result|'s
+                          [=push event result/app badge set=].
                         </p>
                       </li>
                     </ol>
@@ -1740,6 +1777,12 @@
                     <p>
                       If |notificationShown| is false, then run the [=notification show steps=]
                       given |notification|.
+                    </p>
+                  </li>
+                  <li>
+                    <p>
+                      If |appBadgeSet| is false, then <a href=
+                      "https://github.com/w3c/badging/issues/111">w3c/badging #111</a>...
                     </p>
                   </li>
                   <li>
@@ -1761,7 +1804,7 @@
           <li>
             <p>
               Let |result| be the result of [=fire a push event|firing a push event=] given
-              |registration|, |data|, and null.
+              |registration|, |data|, null, and null.
             </p>
           </li>
           <li>
@@ -1779,18 +1822,25 @@
           </li>
         </ol>
         <p>
-          A <dfn>push event result</dfn> is a [=/tuple=] consisting of a <dfn data-dfn-for=
-          "push event result">notification shown</dfn> (a [=/boolean=]).
+          A <dfn>push event result</dfn> is a [=/tuple=] consisting of a <dfn for=
+          "push event result">notification shown</dfn> (a [=/boolean=]) and an <dfn for=
+          "push event result">app badge set</dfn> (a [=/boolean=]).
         </p>
         <p>
           To <dfn>fire a push event</dfn> given a [=/service worker registration=] |registration|,
-          {{PushMessageData}} object or null |data|, and a [=/notification=] or null
-          |notification|, run these steps. They return failure or a [=/push event result=].
+          {{PushMessageData}} object or null |data|, a [=/notification=] or null |notification|,
+          and an integer or null |appBadge|, run these steps. They return failure or a [=/push
+          event result=].
         </p>
         <ol>
           <li>
             <p>
               Let |notificationResult| be null.
+            </p>
+          </li>
+          <li>
+            <p>
+              Let |appBadgeResult| be null.
             </p>
           </li>
           <li>
@@ -1817,6 +1867,12 @@
               <dd>
                 |notification|
               </dd>
+              <dt>
+                {{PushEvent/appBadge}}
+              </dt>
+              <dd>
+                |appBadge|
+              </dd>
             </dl>
             <p>
               Then run the following steps in parallel, with |dispatchedEvent|:
@@ -1830,21 +1886,28 @@
               </li>
               <li>
                 <p>
-                  If they do not resolve successfully, then set |notificationResult| to failure.
+                  If they do not resolve successfully, then set |notificationResult| and
+                  |appBadgeResult| to failure and abort these steps.
                 </p>
               </li>
               <li>
                 <p>
-                  Otherwise, set |notificationResult| to |registration|'s [=service worker
-                  registration/has shownotification() been successfully invoked|has
-                  `showNotification()` been successfully invoked=].
+                  Set |notificationResult| to |registration|'s [=service worker registration/has
+                  shownotification() been successfully invoked|has `showNotification()` been
+                  successfully invoked=].
+                </p>
+              </li>
+              <li>
+                <p>
+                  Set |appBadgeResult| to true if {{NavigatorBadge/setAppBadge()}} has been
+                  invoked; otherwise false.
                 </p>
               </li>
             </ol>
           </li>
           <li>
             <p>
-              Wait for |notificationResult| to be non-null.
+              Wait for |notificationResult| and |appBadgeResult| to be non-null.
             </p>
           </li>
           <li>
@@ -1854,12 +1917,12 @@
           </li>
           <li>
             <p>
-              [=/Assert=]: |notificationResult| is a [=/boolean=].
+              [=/Assert=]: |notificationResult| and |appBadgeResult| are [=/booleans=].
             </p>
           </li>
           <li>
             <p>
-              Return (|notificationResult|).
+              Return (|notificationResult|, |appBadgeResult|).
             </p>
           </li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@
             </dt>
             <dd>
               <p>
-                A [=/64-bit unsigned integer=].
+                A boolean or a [=/64-bit unsigned integer=].
               </p>
               <p class="note">
                 Platform conventions are likely to impose a lower limit with regards to what is


### PR DESCRIPTION
To land this https://github.com/w3c/badging/issues/111 needs to be completed. I'd like some help with that. @marcoscaceres maybe?

---

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation support:
 
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)
 * [x] WebKit


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/pull/402.html" title="Last updated on Sep 15, 2025, 2:21 AM UTC (cfc1388)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/402/54d5cb1...cfc1388.html" title="Last updated on Sep 15, 2025, 2:21 AM UTC (cfc1388)">Diff</a>