### PR TITLE
Define and use the p256dh/auth internal slots

### DIFF
--- a/index.html
+++ b/index.html
@@ -1481,16 +1481,17 @@
         <li>If |name| is {{PushEncryptionKeyName/"p256dh"}}:
           <ol>
             <li>Set the contents of |key| to the serialized value of the public key from
-            [=P-256 ECDH key pair=], using the uncompressed format defined in [[ANSI-X9-62]] Annex
-            A (that is, a 65 octet sequence that starts with a 0x04 octet), as [[RFC8291]]
-            specifies.
+            [=this=]'s [=P-256 ECDH key pair=], using the uncompressed format defined in
+            [[ANSI-X9-62]] Annex A (that is, a 65 octet sequence that starts with a 0x04 octet), as
+            [[RFC8291]] specifies.
             </li>
           </ol>
         </li>
         <li>Otherwise:
           <ol>
             <li>[=/Assert=]: |name| is {{PushEncryptionKeyName/"auth"}}</li>
-            <li>Set the contents of |key| to a copy of the value from [=authentication secret=].
+            <li>Set the contents of |key| to a copy of the value from [=this=]'s
+            [=authentication secret=].
             </li>
           </ol>
         </li>
@@ -1540,10 +1541,10 @@
         </li>
         <li>Let |keys:PushSubscriptionKeys| be a new {{PushSubscriptionKeys}} dictionary.
         </li>
-        <li>Set |keys|["p256dh"] be the URL-safe base64 encoding without padding [[RFC4648]] of
+        <li>Set |keys|["p256dh"] to the URL-safe base64 encoding without padding [[RFC4648]] of
         the value as returned by {{PushSubscription/getKey("p256dh")}}, as a {{USVString}}.
         </li>
-        <li>Set |keys|["auth"] be the URL-safe base64 encoding without padding [[RFC4648]] of
+        <li>Set |keys|["auth"] to the URL-safe base64 encoding without padding [[RFC4648]] of
         the value as returned by {{PushSubscription/getKey("auth")}}, as a {{USVString}}.
         </li>
         <li>Set |json|["keys"] to |keys|.

--- a/index.html
+++ b/index.html
@@ -1443,8 +1443,7 @@
           PushSubscriptionJSON toJSON();
         };
         
-        dictionary PushSubscriptionKeys
-        {
+        dictionary PushSubscriptionKeys {
           USVString p256dh;
           USVString auth;
         };
@@ -1475,7 +1474,7 @@
         The <dfn>getKey</dfn><code>(|name:PushEncryptionKeyName|)</code> method retrieves keying
         material that can be used for encrypting and authenticating messages. The method steps are:
       </p>
-      <ol>
+      <ol class="algorithm">
         <li>Let |key| be a newly instantiated {{ArrayBuffer}} instance.
         </li>
         <li>If |name| is {{PushEncryptionKeyName/"p256dh"}}:

--- a/index.html
+++ b/index.html
@@ -1472,11 +1472,10 @@
         subscription</a>.
       </p>
       <p>
-        The <dfn>getKey</dfn><code>(|name:PushEncryptionKeyName|)</code> method retrieves keying
-        material that can be used for encrypting and authenticating messages. The method steps are:
+        The <dfn>getKey</dfn><code>(|name:PushEncryptionKeyName|)</code> method steps are:
       </p>
       <ol class="algorithm">
-        <li>Let |key| be a newly instantiated {{ArrayBuffer}} instance.
+        <li>Let |key| be a new {{ArrayBuffer}} object.
         </li>
         <li>If |name| is {{PushEncryptionKeyName/"p256dh"}}:
           <ol>

--- a/index.html
+++ b/index.html
@@ -760,7 +760,8 @@
           [=ECDH=] key pair [[ANSI-X9-62]].
           </li>
           <li>Set |subscription|'s [=authentication secret=] to the result of generating a new
-          authentication secret, which is a sequence of octets as defined in [[RFC8291]].
+          authentication secret, which is a sequence of octets as defined in [[RFC8291]] Section
+          3.2.
           </li>
           <li>Request a new <a>push subscription</a>. Include the
           {{PushSubscriptionOptions/applicationServerKey}} attribute of |options| when it has been

--- a/index.html
+++ b/index.html
@@ -735,9 +735,8 @@
           SHOULD attempt to <a>refresh</a> the push subscription before the subscription expires.
         </p>
         <p>
-          A <a>push subscription</a> has internal slots for a P-256 <a>ECDH</a> key pair and an
-          authentication secret in accordance with [[RFC8291]]. These slots MUST be populated when
-          creating the <a>push subscription</a>.
+          A [=push subscription=] has an associated <dfn>P-256 ECDH key pair</dfn> and an
+          <dfn>authentication secret</dfn> in accordance with [[RFC8291]].
         </p>
         <p>
           If the <a>user agent</a> has to change the keys of a [=push subscription=] for any reason
@@ -757,16 +756,11 @@
           </li>
           <li>Set |subscription|'s {{PushSubscription/options}} attribute to |options|.
           </li>
-          <li>Generate a new P-256 <a>ECDH</a> key pair [[ANSI-X9-62]]. Store the private key in an
-          internal slot on |subscription|; this value MUST NOT be made available to applications.
-          The public key is also stored in an internal slot and can be retrieved by calling the
-          {{PushSubscription/getKey()}} method of the {{PushSubscription}} with an argument of
-          {{PushEncryptionKeyName/"p256dh"}}.
+          <li>Set |subscription|'s [=P-256 ECDH key pair=] to the result of generating a new P-256
+          [=ECDH=] key pair [[ANSI-X9-62]].
           </li>
-          <li>Generate a new authentication secret, which is a sequence of octets as defined in
-          [[RFC8291]]. Store the authentication secret in an internal slot on |subscription|. This
-          key can be retrieved by calling the {{PushSubscription/getKey()}} method of the
-          {{PushSubscription}} with an argument of {{PushEncryptionKeyName/"auth"}}.
+          <li>Set |subscription|'s [=authentication secret=] to the result of generating a new
+          authentication secret, which is a sequence of octets as defined in [[RFC8291]].
           </li>
           <li>Request a new <a>push subscription</a>. Include the
           {{PushSubscriptionOptions/applicationServerKey}} attribute of |options| when it has been
@@ -1448,11 +1442,17 @@
 
           PushSubscriptionJSON toJSON();
         };
+        
+        dictionary PushSubscriptionKeys
+        {
+          USVString p256dh;
+          USVString auth;
+        };
 
         dictionary PushSubscriptionJSON {
           USVString endpoint;
           EpochTimeStamp? expirationTime = null;
-          record&lt;DOMString, USVString&gt; keys;
+          PushSubscriptionKeys keys;
         };
       </pre>
       <p>
@@ -1472,37 +1472,31 @@
         subscription</a>.
       </p>
       <p>
-        The <dfn>getKey()</dfn> method retrieves keying material that can be used for encrypting
-        and authenticating messages. When {{PushSubscription/getKey()}} is invoked the following
-        process is followed:
+        The <dfn>getKey</dfn><code>(|name:PushEncryptionKeyName|)</code> method retrieves keying
+        material that can be used for encrypting and authenticating messages. The method steps are:
       </p>
       <ol>
-        <li>Find the internal slot corresponding to the key named by the `name` argument.
+        <li>Let |key| be a newly instantiated {{ArrayBuffer}} instance.
         </li>
-        <li>If a slot was not found, return `null`.
+        <li>If |name| is {{PushEncryptionKeyName/"p256dh"}}:
+          <ol>
+            <li>Set the contents of |key| to the serialized value of the public key from
+            [=P-256 ECDH key pair=], using the uncompressed format defined in [[ANSI-X9-62]] Annex
+            A (that is, a 65 octet sequence that starts with a 0x04 octet), as [[RFC8291]]
+            specifies.
+            </li>
+          </ol>
         </li>
-        <li>Initialize a variable |key| with a newly instantiated {{ArrayBuffer}} instance.
-        </li>
-        <li>If the internal slot contains an asymmetric key pair, set the contents of |key| to the
-        serialized value of the public key from the key pair. This uses the serialization format
-        described in the specification that defines the name. For example, [[RFC8291]] specifies
-        that the {{PushEncryptionKeyName/"p256dh"}} public key is encoded using the uncompressed
-        format defined in [[ANSI-X9-62]] Annex A (that is, a 65 octet sequence that starts with a
-        0x04 octet).
-        </li>
-        <li>Otherwise, if the internal slot contains a symmetric key, set the contents of |key| to
-        a copy of the value from the internal slot. For example, the `auth` parameter contains an
-        octet sequence used by the <a>user agent</a> to authenticate messages sent by an
-        <a>application server</a>.
+        <li>Otherwise:
+          <ol>
+            <li>[=/Assert=]: |name| is {{PushEncryptionKeyName/"auth"}}</li>
+            <li>Set the contents of |key| to a copy of the value from [=authentication secret=].
+            </li>
+          </ol>
         </li>
         <li>Return |key|.
         </li>
       </ol>
-      <p data-link-for="">
-        Keys named {{PushEncryptionKeyName/"p256dh"}} and {{PushEncryptionKeyName/"auth"}} MUST be
-        supported, and their values MUST correspond to those necessary for the user agent to
-        decrypt received push messages in accordance with [[RFC8291]].
-      </p>
       <p>
         The <dfn data-lt="unsubscribed">unsubscribe()</dfn> method when invoked MUST run the
         following steps:
@@ -1544,24 +1538,13 @@
         <li>Set |json|["expirationTime"] to the result of [=getting the `expirationTime`
         attribute=] of [=this=].
         </li>
-        <li>Let |keys| be a new empty instance of `record&lt;DOMString, USVString&gt;` .
+        <li>Let |keys:PushSubscriptionKeys| be a new {{PushSubscriptionKeys}} dictionary.
         </li>
-        <li>For each identifier |i| corresponding to keys in internal slots on the
-        {{PushSubscription}}, ordered by the name of the key:
-          <ol>
-            <li>If the internal slot corresponds to an asymmetric key pair, let |b| be the encoded
-            value of the public key corresponding to the key name |i|, using the encoding defined
-            for the key name (see {{PushSubscription/getKey()}}).
-            </li>
-            <li>Otherwise, let |b| be the value as returned by {{PushSubscription/getKey}}.
-            </li>
-            <li>Let |s| be the URL-safe base64 encoding without padding [[RFC4648]] of |b| as a
-            {{USVString}}. The <a>user agent</a> MUST use a serialization method that does not
-            branch based on the value of |b|.
-            </li>
-            <li>Set |keys|[|i|] to |s|.
-            </li>
-          </ol>
+        <li>Set |keys|["p256dh"] be the URL-safe base64 encoding without padding [[RFC4648]] of
+        the value as returned by {{PushSubscription/getKey("p256dh")}}, as a {{USVString}}.
+        </li>
+        <li>Set |keys|["auth"] be the URL-safe base64 encoding without padding [[RFC4648]] of
+        the value as returned by {{PushSubscription/getKey("auth")}}, as a {{USVString}}.
         </li>
         <li>Set |json|["keys"] to |keys|.
         </li>


### PR DESCRIPTION
Closes #396.

The current spec assumes random kinds of keys may exist, even though there has been only two kinds of keys, which is unlikely to change. Given that adds more prose for no use, this patch defines separate internal slots for each key.

Technically this change can be done without the dictionary change. I can split it if desired.

The following tasks have been completed:

 * [x] Modified Web platform tests (N/A)

Implementation commitment:
 
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=) - [currently does not use dictionaries at all but returns an `object`](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/push_messaging/push_subscription.idl;l=24;drc=047c7dc4ee1ce908d7fea38ca063fa2f80f92c77)
 * [x] Gecko (since 2015)
 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/pull/414.html" title="Last updated on Dec 8, 2025, 8:49 AM UTC (573251b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/push-api/414/ebd170f...573251b.html" title="Last updated on Dec 8, 2025, 8:49 AM UTC (573251b)">Diff</a>